### PR TITLE
feat: add chatbot title heading to consent screen

### DIFF
--- a/static/qa.html
+++ b/static/qa.html
@@ -120,6 +120,7 @@
 <body class="d-flex flex-column vh-100" style="position: relative;">
   <div id="consent-overlay" class="consent-overlay">
     <div class="consent-box">
+      <h4 style="color: var(--chatbot-primary); margin-bottom: 20px;"><i class="bi bi-chat-dots"></i> IITM BS Admissions Chatbot</h4>
       <h5><i class="bi bi-robot"></i> Before You Start</h5>
       <p>Please note the following:</p>
       <ul>


### PR DESCRIPTION
## Summary

- Added "IITM BS Admissions Chatbot" heading with chat icon to the consent screen
- Displays above the "Before You Start" warning section

## Test plan

- [ ] Verify heading appears on consent screen
- [ ] Check styling matches the theme (royal blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)