### PR TITLE
Token-based chunking for FAQ embeddings

### DIFF
--- a/src/faq_1.md
+++ b/src/faq_1.md
@@ -1,0 +1,30 @@
+Q1: What exactly is the qualifier exam in the IIT Madras BS program?
+Answer: The qualifier exam is a 4‑hour in‑person exam held after 4 weeks of online classes and assignments, covering the four basic courses from the qualifier phase (like Math, stats/English, programming, etc.). It tests only the content taught in those 4 weeks, and clearing it with the required cut‑offs makes you eligible to register for the Foundation level of the IITM BS program.
+
+Q2: Why is the qualifier exam required to join the degree program?
+Answer: Yes, the Qualifier Exam is mandatory for all regular entry applicants to earn admission to the Foundation Level of the IIT Madras BS programme. Regular entryapplicants must go through the 4-week Qualifier process, which includes completing assignments and passing the exam to qualify for the Foundation Level courses.
+
+Q3: Is the qualifier exam the same for all programs?
+Answer: BS in Data Science and Applications (DS) includes:
+
+English 1
+Maths-1
+Statistics-1
+Computational Thinking
+BS in Electronic Systems (ES) includes:
+
+ English I, Math for Electronics I, Electronic Systems Thinking and Circuits, and Introduction to C Programming
+
+Q4: Is the qualifier exam different for Data Science and Electronic Systems?
+Answer: BS in Data Science and Applications (DS) includes:
+
+English 1
+Maths-1
+Statistics-1
+Computational Thinking
+BS in Electronic Systems (ES) includes:
+
+ English I, Math for Electronics I, Electronic Systems Thinking and Circuits, and Introduction to C Programming
+
+Q5: Is clearing the qualifier mandatory to register for Foundation courses?
+Answer: Yes, clearing the Qualifier Exam is mandatory to register for Foundation courses for regular entry applicants. Only those who successfully complete the Qualifier process will be eligible to join the Foundation Level of the IIT Madras BS programme.

--- a/src/faq_10.md
+++ b/src/faq_10.md
@@ -1,0 +1,14 @@
+Q42: How are qualifier exam cities allocated?
+Answer: https://docs.google.com/spreadsheets/d/e/2PACX-1vRFM0LWNJWSELYXxXFdpHxu0ghiCDOE6uHneSWH-eIIg-4X91gSyMAy0m05RJDiklK-G0KJ0GasGywp/pubhtml?gid=0&single=true
+
+Q43: Can I choose my qualifier exam city?
+Answer: Yes, you can select the qualifier exam city. The exam city selection option is available during your application process.
+
+Q44: Can I change my qualifier exam city after selection?
+Answer: Yes, you can change the exam city option after selection. We will provide you a exam city edit window during which the student can chnage their exam city. The dates in which they cann change will be notified by the team when the window opens. The notifiecation is sent over mail to your registered mail id.
+
+Q45: Are exam centers available in all states?
+Answer: You may check the exam cities here: https://docs.google.com/spreadsheets/d/e/2PACX-1vRFM0LWNJWSELYXxXFdpHxu0ghiCDOE6uHneSWH-eIIg-4X91gSyMAy0m05RJDiklK-G0KJ0GasGywp/pubhtml?gid=0&single=true
+
+Q46: What documents are required at the exam center?
+Answer: The students are required to carry a original proof like aadhar card/pan card/passport/college id card to the exam center along with the photocopy of the hall ticket.

--- a/src/faq_11.md
+++ b/src/faq_11.md
@@ -1,0 +1,20 @@
+Q47: Is Aadhaar mandatory for qualifier exam entry?
+Answer: The students are required to carry a original proof like aadhar card/pan card/passport/college id card to the exam center along with the photocopy of the hall ticket.
+
+Q48: What happens if I forget my hall ticket?
+Answer: The students must mandatorily bring the physical hall ticket to the exam center.
+
+Q49: Can I request special accommodation for the qualifier exam?
+Answer: If you are a physically challenged student or need any special exception in seating then you may mail support@study.iitm.ac.in two weeks before the exam and place a request with valid proof.
+
+Q50: Is a scribe allowed for qualifier exams?
+Answer: Yes, if you are a physically challenged student and need support for scribe then two weeks before the exam our team will contact you for help required.
+
+Q51: When are qualifier results announced?
+Answer: The qualfiier results for the Jan 2026 term will be released on March 19, 2026. For other term dates please check https://study.iitm.ac.in/ds/admissions.html#AD0
+
+Q52: Where can I check my qualifier result?
+Answer: The qualifier exam results will be updated on the student dashboard. You will be notified to your registered student mail id when the results are announced.
+
+Q53: What does “qualifier cleared” status mean?
+Answer: The quallified cleared status means you have cleared the qualifier exam and you may proceed to register for the foundation level.

--- a/src/faq_12.md
+++ b/src/faq_12.md
@@ -1,0 +1,25 @@
+Q54: How long is the qualifier result valid?
+Answer: The qualifier marks will be valid for the 3 terms that come subsequent to the qualifier exam date
+for the learner to register to the Foundation level. This score will be invalid after this period and
+the learner will have to go through the entire qualifier process (the 1 month of weekly
+assignments) and retake the qualifier exam, if they wish to join the programme.
+For students in std XII who take the qualifier exam, the validity is for 3 terms from when
+they pass std XII.
+
+Q55: Is validity different for Class 12 students?
+Answer: The qualifier marks will be valid for the 3 terms that come subsequent to the qualifier exam date
+for the learner to register to the Foundation level. This score will be invalid after this period and
+the learner will have to go through the entire qualifier process (the 1 month of weekly
+assignments) and retake the qualifier exam, if they wish to join the programme.
+For students in std XII who take the qualifier exam, the validity is for 3 terms from when
+they pass std XII.
+
+Q56: Does qualifier validity expire automatically?
+Answer: Yes, the validity of the qualifier marks expires automatically after a certain period. The qualifier marks will be valid for the 3 terms that come subsequent to the qualifier exam date. After this period, the score will be considered invalid, and the learner will have to go through the entire qualifier process again, including the 1 month of weekly assignments and retaking the qualifier exam if they wish to join the program.
+
+Q57: What happens if my qualifier validity expires?
+Answer: If your qualifier score validity expires, the following will happen:
+
+The score will be invalid after the validity period.
+You will have to go through the entire qualifier process again, which includes completing the 1 month of weekly assignments.
+You must retake the qualifier exam if you wish to join the programme again.

--- a/src/faq_13.md
+++ b/src/faq_13.md
@@ -1,0 +1,17 @@
+Q58: Can qualifier validity be extended?
+Answer: No, the qualifier validity cannot be extended. The qualifier marks are valid for 3 terms following the exam date, and once this period expires, the score becomes invalid. You will then need to go through the entire qualifier process again, including completing the weekly assignments and retaking the qualifier exam if you wish to join the programme.
+
+Q59: Can I use the same qualifier result for future terms?
+Answer: No, you cannot use the same qualifier result for future terms. The qualifier marks are valid for 3 terms following the exam date. After this period, if you have not registered for the Foundation level, the score will expire, and you will need to go through the entire qualifier process again, including retaking the qualifier exam.
+
+Q60: Will I receive a certificate for clearing the qualifier?
+Answer: The students who are qualifief will be issued a admission letter. The admission letter gives the terms until which the qualifier score is valid.
+
+Q61: What happens if I fail the qualifier exam?
+Answer: If you fail the qualifier exam, you have the following options:
+
+Reattempt in the Same Term: You can apply for a reattempt within the same term if you meet the eligibility criteria. This applies if you were absent for the exam or if you failed the first attempt.
+
+Subsequent Terms: If you did not achieve the minimum assignment scores and did not become eligible for the qualifier exam, there are no limits on the number of times you can attempt the qualifier process in subsequent terms. You will need to pay the full fees applicable for your category and redo the 4 weeks of course work and weekly graded assignments to become eligible again.
+
+Fresh Application: If you attempt the qualifier process again in a subsequent term, it will be considered a fresh application, and you must meet all requirements to qualify for the exam.

--- a/src/faq_14.md
+++ b/src/faq_14.md
@@ -1,0 +1,21 @@
+Q62: Can I reattempt the qualifier exam?
+Answer: Yes, you can reattempt the qualifier exam under certain conditions:
+
+Within the Same Term: If you were absent for the qualifier exam or if you failed the first attempt, you can apply for a reattempt within the same term. You do not have to repeat the assignments as you have already become eligible.
+
+Subsequent Terms: If you did not achieve the minimum assignment scores and did not become eligible for the qualifier exam, you can attempt the qualifier process again in subsequent terms. There are no limits on the number of times you can attempt the qualifier process, but you will need to pay the full fees applicable for your category and redo the 4 weeks of course work and weekly graded assignments to become eligible again.
+
+Q63: Is there a limit on the number of qualifier attempts?
+Answer: there is no any such limit for appearing in qualifier
+
+Q64: Is there a separate fee for qualifier reattempt?
+Answer: es, there is a separate fee for reattempting the qualifier exam within the same term. The reattempt fee varies based on the applicant's category:
+
+Category	Re-attempt Fee
+General Category / OBC Applicant	Two thousand rupees (Rs. 2000)
+SC / ST Category / PwD (40% or more disability) Applicant	One thousand rupees (Rs. 1000)
+SC / ST Category Applicant who is ALSO PwD (40% or more disability)	Five hundred rupees (Rs. 500)
+This fee is applicable if you were absent for the exam or if you failed the first attempt and wish to reattempt within the same term.
+
+Q65: Do I need to redo assignments for reattempt?
+Answer: No. You do not need to redo the assignments, your previously earned assignment scores will be carried forward for the reattempt.

--- a/src/faq_15.md
+++ b/src/faq_15.md
@@ -1,0 +1,28 @@
+Q66: Can I reattempt qualifier in the same term?
+Answer: Yes, you can reattempt the qualifier in the same term.
+
+Q67: Will my previous assignment scores carry forward?
+Answer: Yes. You do not need to redo the assignments, your previously earned assignment scores will be carried forward for the reattempt.
+
+Q68: Can I improve only one subject in reattempt?
+Answer: No, you can't improve your marks if you already passed in Qualifier. If you fail the Qualifier due to a single subject, you do not need to reappear for the entire exam. You can reattempt only the subject in which you did not clear the Qualifier.
+
+Q69: Is reattempt difficulty level the same?
+Answer: Yes, the same. The syllabus remains the same for the qualifier - reattempt examination.
+
+Q70: Does failing qualifier affect future admissions?
+Answer: No, you can still join later by reattempting on subsequent month.
+
+Q71: Who is exempted from the qualifier exam?
+Answer: Candidates who have qualified in JEE Main within the last two years are exempted from appearing for the Qualifier exam.
+
+Q72: How does JEE Advanced exemption work?
+Answer: JEE Advanced Exemption Process
+Candidates eligible to attempt the most recent JEE Advanced (e.g., qualified JEE Main CRL rank ≤2.5 lakh) are automatically exempt from the qualifier exam.
+
+
+How to Claim
+Apply during the regular application window (₹3,000-4,000 fee), upload JEE Main scorecard/proof of Advanced eligibility for verification, then directly access Foundation course registration (pay ₹6,000 registration fee + course fees
+
+Q73: Which JEE Advanced years are eligible for exemption?
+Answer: A student can apply as  a JEE based applicant  till Sep 2026 if he/she has qualfied JEE mains in the year 2024

--- a/src/faq_16.md
+++ b/src/faq_16.md
@@ -1,0 +1,19 @@
+Q74: Do exempted students need to do qualifier assignments?
+Answer: All the regular based applicants must mandatorily submit the assignments as the qulaifier eligibility depends on the assignment scores
+
+Eligibility to appear for the qualifier exam
+At the end of the 4 weeks, a qualifier exam will be conducted for eligible candidates based on
+the content covered in the 4 weeks of study.
+Each assignment will be graded out of 100
+Any assignment that is not attempted will be marked as 0.
+● If the average of the first 2 weeks’ assignment scores is >= 40/100 (or as per the cutoff
+for each category of students) in each of the 4 subjects, the students will be eligible to
+write the qualifier exam in the first attempt within the term.
+● For those who do not qualify after the week 2 assignments, the average of the best 2 out
+of the first 3 weeks’ assignment scores will be considered. If this score is >= 40/100 (or
+as per the cutoff for each category of students) in each of the 4 subjects, the students
+will become eligible to write the qualifier exam in the second attempt within the term.
+● Reattempts within the term will be given suitably.
+
+Q75: Can exemption be claimed after applying normally?
+Answer: No. It is not possible for changing this option. Once the application has been submitted for regular entry, it cannot be changed for that particular term.

--- a/src/faq_17.md
+++ b/src/faq_17.md
@@ -1,0 +1,18 @@
+Q76: What proof is required for qualifier exemption?
+Answer: For students seeking exemption from the qualifier exam through the JEE-Based Entry pathway, the following documents are required:
+
+Valid proof of eligibility for JEE Advanced - admit card or JEE Mains score card. This proof is necessary to ensure that the candidate qualifies for direct admission to the Foundation Level without needing to complete the qualifier process. If the proof is valid, the candidate will be declared eligible to join the program directly.
+
+Q77: Can exemption be rejected?
+Answer: Yes, an exemption may be rejected if the required criteria is not met or the relevant documents are not submitted.
+
+Q78: Can exempted students directly register for courses?
+Answer: No, there are no "exempted students" for the qualifier or Foundation in the IITM BS online program, so no one registers directly for courses without it
+
+Q79: Is exemption available for other national exams?
+Answer: The students who are JEE advance eligible can apply as a JEE based entrant and join the BS in Data science program.
+Students who are eligible for JEE advance from JAN 2024 can apply for the program till Sep 2026.
+
+Q80: Can international exams be used for exemption?
+Answer: No, international exams like AP, SAT, A-Levels, or IB cannot be used for exemptions or credit transfers in the IITM BS program.
+​Only NPTEL/SWAYAM courses (approved ones) qualify for credit transfer at later levels (e.g., BSc/BS), but the qualifier and Foundation require completing IITM's coursework without such exemptions.

--- a/src/faq_18.md
+++ b/src/faq_18.md
@@ -1,0 +1,20 @@
+Q81: 🔹 Post-Qualifier Process
+Answer: Check your dashboard/email for results within 1-2 weeks of the exam.
+​
+
+Access the Course Registration Form (opens immediately post-results), select 1-4 Foundation courses based on your score, upload Class 12/caste docs, choose exam cities, pay fees (~₹6,000/course), and submit before the deadline (1-4 days).
+​
+​
+
+Attend orientation, complete Week 5-6 assignments, and start the term (or defer up to 3 terms validity
+
+Q82: What should I do after clearing the qualifier?
+Answer: After clearing the qualifier, check your dashboard for results (usually within 1-2 weeks), then complete course registration (select up to 4 Foundation courses based on your score, upload Class 12 docs if needed, choose exam cities, pay fees ~₹6,000/course)
+
+Q83: How soon can I register for Foundation courses?
+Answer: You can register for Foundation courses as soon as you receive your admission letter after successfully completing the qualifier exam. If you are a JEE-based entry candidate and your proof of eligibility is valid, you can register for the Foundation courses immediately after verification.
+
+For regular entry candidates, registration for Foundation courses will be available after passing the qualifier exam.
+
+Q84: Is course registration automatic after qualifier?
+Answer: No, course registration is not automatic after clearing the qualifier—you must log in to the portal, access the registration form, select courses (up to 4 based on your score), upload proof of Class 12 completion, and pay the course fees.

--- a/src/faq_19.md
+++ b/src/faq_19.md
@@ -1,0 +1,14 @@
+Q85: Can I delay course registration after clearing qualifier?
+Answer: Yes, but to a limited period. 
+The qualifier marks will be valid for the 3 terms that come subsequent to the qualifier exam date for the learner to register to the Foundation level. This score will be invalid after this period and the learner will have to go through the entire qualifier process (the 1 month of weekly assignments) and retake the qualifier exam, if they wish to join the programme.
+
+For students in std XII who take the qualifier exam, the validity is for 3 terms from when they pass std XII.
+
+Q86: What happens if I clear qualifier but don’t register?
+Answer: If you clear the qualifier but don't register for Foundation courses within the validity period (3 terms or ~1 year for Class 12 completers), your qualifier result expires and you must reapply and redo the entire qualifier process
+
+Q87: Will I lose my seat if I delay registration?
+Answer: No, you will not lose your qualifier status ("seat") if you delay registration—the result is valid for 3 terms (about 1 year), allowing you to register later without redoing the exam.
+
+Q88: Can I clear qualifier and take a break before joining?
+Answer: Yes, you can take a break after clearing the qualifier before starting Foundation courses—the result is valid for 3 terms (about 1 year) for those who have completed Class 12

--- a/src/faq_2.md
+++ b/src/faq_2.md
@@ -1,0 +1,17 @@
+Q6: Can I join the program without taking the qualifier exam?
+Answer: No, you cannot join the program without taking the Qualifier Exam if you are a regular entry applicant. The Qualifier Exam is a mandatory requirement for admission to the Foundation Level of the IIT Madras BS programme. Only candidates who qualify through this process can register for the Foundation courses.
+
+However, if you have qualified for the JEE Advanced Exams, you may have a direct entry into the Foundation Level without needing to take the Qualifier Exam.
+
+Q7: Is the qualifier a competitive exam or only qualifying?
+Answer: The Qualifier Exam is primarily a qualifying exam, not a competitive one. Candidates must achieve the minimum required scores in each subject and an overall average to pass. The exam is designed to assess whether candidates meet the necessary criteria to join the Foundation Level of the IIT Madras BS programme
+
+Q8: Does clearing the qualifier guarantee admission?
+Answer: yes, it is guaranteed if you clear the qualifier until and unless without any documentation problem.
+
+Q9: Is there a cutoff score for the qualifier exam?
+Answer: Yes, there is a cutoff, and it is applied both per subject and on your overall average.
+You must score at least around 40% per subject and 50% overall if you are in the general category (with slightly lower thresholds for OBC‑NCL/EWS and SC/ST/PwD categories), and only if you clear both the subject‑wise and overall cutoff are you considered to have passed the qualifier
+
+Q10: Who conducts the qualifier exam?
+Answer: The qualifier exam is conducted by the IIT Madras BS program administration. They are responsible for organizing the exam, including scheduling, providing the exam content, and managing the evaluation process.

--- a/src/faq_20.md
+++ b/src/faq_20.md
@@ -1,0 +1,9 @@
+Q89: Does clearing qualifier lock my program choice?
+Answer: Clearing the qualifier for Data Science locks your oppurtunity to join the Data Science program. Similarly, clearing the qualifier for Electronic Systems locks your oppurtunity to join the Electronic Systems program. However, you will have to join the foundation level of the program within the term, mentioned in the admission letter. 
+
+The qualifier marks will be valid for the 3 terms that come subsequent to the qualifier exam date for the learner to register to the Foundation level. This score will be invalid after this period and the learner will have to go through the entire qualifier process (the 1 month of weekly assignments) and retake the qualifier exam, if they wish to join the programme. For students in std XII who take the qualifier exam, the validity is for 3 terms from when they pass std XII.
+
+Q90: Can I change program after qualifier?
+Answer: No, it is not possible.
+If the student attempts the qualifier exam for Data Science and clears the qualifier exam, then it is not possible to shift from Data Science to Electronic Systems. 
+Likewise, If the student attempt the qualifier exam for Electronic Systems and clears the qualifier exam, then it is not possible to shift from Electronic Systems to Data Science.

--- a/src/faq_21.md
+++ b/src/faq_21.md
@@ -1,0 +1,23 @@
+Q91: Is a separate fee required after qualifier clearance?
+Answer: Yes, after clearing the qualifier exam, the course registration payment is required, based on the number of courses they register to, in the foundation level. 
+
+Level wise fee payment: Goal Total Credits 
+Total Fees INR 
+
+Foundation only 32 ₹48,000 
+Foundation + One Diploma 59 ₹1,29,000 
+Foundation + Two Diplomas 86 ₹2,10,000 
+BSc Degree 114 ₹2,86,000 - ₹3,10,000 
+BS Degree 142 ₹3,86,000 - ₹4,50,000 
+PG Diploma in AI & ML 162 (BS + PG Diploma) ₹4,86,000 - ₹5,90,000 
+MTech in AI & ML 182 (BS + PG Diploma + MTech) ₹6,86,000 - ₹7,90,000
+
+Q92: Is qualifier easier or harder than end-term exams?
+Answer: Students and IITM faculty generally consider the qualifier to be moderately difficult but easier than the regular term (quiz + end‑term) exams, as long as you stay consistent with lectures and assignments
+
+Q93: How much time should I prepare for the qualifier?
+Answer: The qualifier spans just 4 weeks of coursework (about 10 hours/week expected engagement per course), so dedicate 4-7 hours daily consistently to lectures, assignments, and practice across the 4 subjects to clear it comfortably.
+
+Q94: Is coaching required to clear the qualifier?
+Answer: No, coaching is not required to clear the qualifier—IITM explicitly states you can self‑study the 4 weeks' content without going to any coaching center.
+​Most students clear it through consistent self‑study of lectures, assignments, and PYQs, though optional coaching exists for extra support if needed.

--- a/src/faq_22.md
+++ b/src/faq_22.md
@@ -1,0 +1,22 @@
+Q95: Can I clear qualifier with self-study?
+Answer: Yes, you can definitely clear the qualifier with self‑study—IITM's FAQ explicitly confirms it is based on 4 weeks of provided content, and no coaching is needed
+
+Q96: Are past qualifier question papers available?
+Answer: Yes, past qualifier question papers are available through student communities and websites like gradedassignments.github.io/iit-madras-pyq and quizpractice.space.
+
+Q97: Does qualifier test coding skills?
+Answer: No, the qualifier exam tests Computational Thinking (basic pseudocode, flowcharts, boolean logic, and simple algorithms) rather than advanced coding skills or programming in a language.
+
+Q98: Is English compulsory in the qualifier exam?
+Answer: yes , english 1 is compulsory.
+
+Q99: Can I skip a subject in the qualifier exam?
+Answer: No, students cannot skip a subject in the qualifier exam as it is mandatory to attempt all the four subjects for the qualifier examinatino. To pass the exam, students must meet the minimum required percentage in each subject as well as score the necessary average score across all subjects based on their category
+
+Q100: What is the most common reason students fail qualifier?
+Answer: The following may be few of the common reasons because of which the students do not clear the qualifier exam:
+Not meeting individual and overall cut-off, as a minimum eligibility score in each subject based on the category is mandatory.
+Inadequate preparation during the 4-week study period may impact exam performance.
+Absence from the exam and others.
+
+Students can improve their chances of clearing the qualifier by thoroughly understanding the course content and completing all assignments during the preparation period.

--- a/src/faq_23.md
+++ b/src/faq_23.md
@@ -1,0 +1,24 @@
+Q101: Who should I contact for qualifier-related issues?
+Answer: For any issues related to the qualifier process, please mail to support-qualifier@study.iitm.ac.in 
+You can also check the official website for a detailed information. Website link: https://study.iitm.ac.in/ds/
+
+Q102: Is prior coding knowledge required?
+Answer: No. The program starts from basic concepts. But you have to put in effort and a lot of practice to learn coding if you have never done it before.
+
+Q103: Is the academic schedule available anywhere?
+Answer: The academic schedule for the qualifier Jan 2026 term can be seen under the important dates under admission tab. https://study.iitm.ac.in/ds/admissions.html#AD0
+
+Q104: Can commerce or non-science students apply?
+Answer: Yes, students from non-science or commerce stream can apply for the BS in Data science and applications program, provided they have completed English and mathematics in class 10.
+
+Q105: Will I get recorded lectures?
+Answer: Yes. All video lectures are pre-recorded and accessible anytime. All videos are on youtube for all the courses. You can go through them even before joining the program to see if they are accessible to you.
+
+Q106: Is the BS degree equivalent to the BTech degree?
+Answer: No, it is not equivalent to the BTech degree. But it is a valid 4 year degree from IIT Madras.
+
+Q107: Is the degree awarded by IIT Madras valid?
+Answer: Yes, it is a 4 year undergraduate degree as valid as the BTech from IITM.
+
+Q108: Can Class 11 students apply?
+Answer: School students who have appeared for their Class 11 final exams can apply irrespective of their group/stream/board to the BS in Data science and applications program. Those who qualify can join the program after passing Class 12.

--- a/src/faq_24.md
+++ b/src/faq_24.md
@@ -1,0 +1,26 @@
+Q109: I am already pursuing another degree. Can I apply?
+Answer: Yes. You may pursue this program alongside another degree or job.
+
+Q110: What are the ways to enter the BS program?
+Answer: There are two entry routes:
+Qualifier Exam Route
+Direct Entry via JEE Advanced (eligible years only)
+https://study.iitm.ac.in/ds/admissions.html#AD8
+
+Q111: I’m unable to write the qualifier exam do i will be getting my money back
+Answer: Ans: 
+Refund Policy for Qualifier Exam Fees
+According to the official documentation regarding the Qualifier Exam fees:
+
+Application Fee: The application fee for the Qualifier exam is non-refundable under any circumstances. This includes situations where a candidate is unable to write the exam due to absence or failure.
+
+Re-attempt Fee: Similarly, if you are unable to write the exam and wish to re-attempt, the re-attempt fee is also non-refundable.
+
+Important Notes
+Since the fees are non-refundable, it is advisable to consider this before making any decisions regarding your participation in the Qualifier Exam.
+
+Q112: I had completed my JEE Mains in 2023 and qualified for JEE Advance, and I wanted to know whether I can apply for the program now?
+Answer: The JEE scores are valid for three terms. Since you qualified for JEE Advanced in 2023, your scores are no longer valid, and you will be enrolled from the qualifier level of the program.
+
+Q113: Can I enter as a qualifier applicant and then shift to a JEE based entrant?
+Answer: No, a student who is entering as a qualifier cannot swap to JEE based entry.

--- a/src/faq_3.md
+++ b/src/faq_3.md
@@ -1,0 +1,20 @@
+Q11: 🔹 Eligibility for Qualifier
+Answer: To be eligible to write the qualifier exam (regular entry), you must first complete the 4‑week qualifier period and score at least the minimum required average in the online assignments in all four courses; only then will you get a hall ticket for the exam.
+​Separately from this, basic program eligibility requires that you have completed Class 12 (or equivalent) with Mathematics and English (or Maths and Physics for the ES program), and school students who have finished Class 11 can do the qualifier but can register for courses only after passing Class 12.
+
+Q12: Who is eligible to appear for the qualifier exam?
+Answer: A learner is eligible to appear for the qualifier exam only if they complete the 4‑week qualifier coursework and achieve the minimum required average assignment score in all four qualifier courses.
+
+Q13: Can a Class 12 student appear for the qualifier?
+Answer: Yes, a Class 12 student can appear for the Qualifier Exam. In fact, students who have completed their Class 11 final examinations are eligible to apply for the Qualifier Exam, and those who pass it can join the program after subsequently completing Class 12.
+
+Q14: Can I attempt the qualifier before completing Class 12?
+Answer: Yes, you can attempt the Qualifier Exam before completing Class 12. Students who have completed their Class 11 final examinations are eligible to apply for the Qualifier Exam. If you pass the Qualifier Exam, you can join the program after you complete Class 12.
+
+Q15: Can diploma holders directly attempt the qualifier?
+Answer: a diploma is considered equivalent to Class 12, then diploma holders may be able to attempt the Qualifier Exam.
+
+For specific eligibility regarding diploma holders, it is advisable to check the official IIT Madras BS programme website
+
+Q16: Can international students write the qualifier exam?
+Answer: Yes, international students can write the Qualifier Exam.

--- a/src/faq_4.md
+++ b/src/faq_4.md
@@ -1,0 +1,31 @@
+Q17: Is there any age restriction for appearing in the qualifier?
+Answer: The program is designed to be inclusive and does not have any age restrictions for applicants.
+
+To proceed, you will need to meet the basic eligibility requirements, which include:
+
+Completing Class 12 or an equivalent examination.
+
+Q18: Do working professionals need special approval for qualifier?
+Answer: As long as they meet the basic eligibility criteria (having passed Class 12 or an equivalent examination), they should be able to apply without any additional approvals.
+
+Q19: Can I write the qualifier if I failed Class 12 earlier?
+Answer: Yes, you can write the Qualifier Exam even if you have failed Class 12 earlier. However to continue to foundation level after clearing the qualifier you should have passed class 12.
+
+Q20: Can I attempt the qualifier while pursuing another degree?
+Answer: Yes, you can attempt the Qualifier Exam while pursuing another degree. As long as you meet the basic eligibility criteria (having passed Class 12 or an equivalent examination), you are eligible to apply for the Qualifier Exam.
+
+Q21: Is Mathematics compulsory to attempt the qualifier?
+Answer: While the IITM BS team prefers candidates to have a foundation in Mathematics, it is not compulsory to have studied advanced Math in school to apply. The program is designed to be inclusive of students from all academic backgrounds (Arts, Commerce, and Science).
+
+How the Qualifier Works
+The Qualifier Exam is not based on your prior school curriculum. Instead, it tests you on the first four weeks of coursework provided by the IITM BS program itself. These four weeks cover:
+
+Mathematics for Data Science
+
+Statistics for Data Science
+
+Computational Thinking
+
+English
+
+As long as you thoroughly learn and understand the content provided during these four weeks of preparatory classes, you will have all the tools necessary to clear the Qualifier Exam, regardless of your previous mathematical background.

--- a/src/faq_5.md
+++ b/src/faq_5.md
@@ -1,0 +1,19 @@
+Q22: How many courses are part of the qualifier preparation?
+Answer: The Qualifier preparation includes four Foundation level courses. These courses are:
+
+For BS in Data Science and Applications (DS):
+
+English 1
+Maths-1
+Statistics-1
+Computational Thinking
+
+Q23: What subjects are included in qualifier preparation?
+Answer: "The Qualifier preparation includes four Foundation level courses. These courses are:
+
+For BS in Data Science and Applications (DS):
+
+English 1
+Maths-1
+Statistics-1
+Computational Thinking"

--- a/src/faq_6.md
+++ b/src/faq_6.md
@@ -1,0 +1,24 @@
+Q24: Are assignments compulsory to appear for the qualifier?
+Answer: Yes, assignements are compulsory to appear for the qualifier.Eligiblity for qulafier 
+Any assignment that is not attempted will be marked as 0.
+● If the average of the first 2 weeks’ assignment scores is >= 40/100 (or as per the cutoff
+for each category of students) in each of the 4 subjects, the students will be eligible to
+write the qualifier exam in the first attempt within the term.
+● For those who do not qualify after the week 2 assignments, the average of the best 2 out
+of the first 3 weeks’ assignment scores will be considered. If this score is >= 40/100 (or
+as per the cutoff for each category of students) in each of the 4 subjects, the students
+will become eligible to write the qualifier exam in the second attempt within the term.
+● Reattempts within the term will be given suitably.
+Only those who get the minimum required average assignment scores in all four courses
+(as given below) will be allowed to appear for the Qualifier Exam.
+
+Minimum Average Assignment Score
+required in each course
+
+General Learner 40%
+SC / ST / PwD with 40% disability 30%
+PwD with 40% disability & SC / ST 30%
+OBC-NCL / EWS 35%
+Note: Relaxations in pass criteria indicated for various categories of learners is applicable ONLY
+for the qualifier process. There will be no relaxations in terms of grades / pass criteria once
+registered into the program.

--- a/src/faq_7.md
+++ b/src/faq_7.md
@@ -1,0 +1,23 @@
+Q25: What is the minimum assignment score required for qualifier eligibility?
+Answer: Any assignment that is not attempted will be marked as 0.
+● If the average of the first 2 weeks’ assignment scores is >= 40/100 (or as per the cutoff
+for each category of students) in each of the 4 subjects, the students will be eligible to
+write the qualifier exam in the first attempt within the term.
+● For those who do not qualify after the week 2 assignments, the average of the best 2 out
+of the first 3 weeks’ assignment scores will be considered. If this score is >= 40/100 (or
+as per the cutoff for each category of students) in each of the 4 subjects, the students
+will become eligible to write the qualifier exam in the second attempt within the term.
+● Reattempts within the term will be given suitably.
+Only those who get the minimum required average assignment scores in all four courses
+(as given below) will be allowed to appear for the Qualifier Exam.
+
+Minimum Average Assignment Score
+required in each course
+
+General Learner 40%
+SC / ST / PwD with 40% disability 30%
+PwD with 40% disability & SC / ST 30%
+OBC-NCL / EWS 35%
+Note: Relaxations in pass criteria indicated for various categories of learners is applicable ONLY
+for the qualifier process. There will be no relaxations in terms of grades / pass criteria once
+registered into the program.

--- a/src/faq_8.md
+++ b/src/faq_8.md
@@ -1,0 +1,28 @@
+Q26: Is assignment eligibility different for reserved categories?
+Answer: Yes, 
+Minimum Average Assignment Score
+required in each course
+
+General Learner 40%
+SC / ST / PwD with 40% disability 30%
+PwD with 40% disability & SC / ST 30%
+OBC-NCL / EWS 35%
+Note: Relaxations in pass criteria indicated for various categories of learners is applicable ONLY
+for the qualifier process. There will be no relaxations in terms of grades / pass criteria once
+registered into the program.
+
+Q27: What happens if I miss qualifier assignments?
+Answer: If the student missed to submit all the asignments they will not be eligible for the qualifier exam. 
+Any assignment that is not attempted will be marked as 0.
+
+Q28: Can I improve assignment scores for qualifier eligibility?
+Answer: No, once you have successfully qualified, you will not be permitted to reattempt the Qualifier Examination during the validity period of your score. This means you cannot improve your assignment scores for qualifier eligibility after you have qualified.
+
+Q29: Are qualifier assignments graded or pass/fail?
+Answer: The qualifier assignments are graded. Each week during the 4-week Qualifier process, candidates must submit graded assignments for each course. These assignments contribute to the overall evaluation and are part of the requirements to qualify for the exam.
+
+Q30: Are assignments proctored during qualifier preparation?
+Answer: Weekly assignments are not proctored and can be completed from home. However, if you meet the assignment score eligibility, the final Qualifier Exam is strictly proctored and conducted in person at an exam center.
+
+Q31: Where can I check my assignment eligibility status?
+Answer: The eligibility status and other relevant information regarding your assignments and qualifier exam will be displayed within your account on the portal.

--- a/src/faq_9.md
+++ b/src/faq_9.md
@@ -1,0 +1,29 @@
+Q32: Is the qualifier exam online or offline?
+Answer: Qualifier is conducted offline for students within India and for students outside India will have remote proctored exam
+
+Q33: Where is the qualifier exam conducted?
+Answer: Qualifier is conducted offline for stduents within India and for students outside India will have remote proctored exam
+
+Q34: How long is the qualifier exam duration?
+Answer: The qualifier exam is 4 hours (240 minutes).
+
+Q35: How many subjects are tested in the qualifier exam?
+Answer: For BS in Data science and application, it covers all 4 foundation subjects (Maths, Statistics, Computational Thinking, English).
+
+Q36: Is the qualifier exam MCQ-based?
+Answer: The qualifier exam will be MCQ, MSQ , numerical based and short answer type questions.
+
+Q37: Is there negative marking in the qualifier exam?
+Answer: No, there is no negative marking for the qualifier exam.
+
+Q38: Can I carry a calculator to the qualifier exam?
+Answer: Calculators will be enabled in the exam window. There is no need of a physical calculator to the exam.
+
+Q39: Is the qualifier exam open book or closed book?
+Answer: The IIT Madras BS qualifier exam is closed book, as it is an in‑person, proctored, invigilated exam similar to the term quizzes and end‑term exams
+
+Q40: Are all subjects tested on the same day?
+Answer: Yes, all the 4 theory courses must be attempted in all same day.
+
+Q41: Will there be separate papers for each subject?
+Answer: There will be 4 subjects in the qualiifer exam, english 1, mathematics 1 , statistics 1 and computational thinking.


### PR DESCRIPTION
Embedding FAQs failed intermittently with `input length exceeds context length`.
A word-count limit didn’t work because **word count ≠ token count** so some files still overflowed Ollama.

This PR switches to **token-based chunking** and enforces a **400-token cap per FAQ document**, keeping Q&A pairs atomic.
With this limit, all FAQ docs embed reliably using `mxbai-embed-large`.

Result: no context-length errors and stable Weaviate embeddings.
