### PR TITLE
Add specific FAQs for may 2026

### DIFF
--- a/src/jee_based_entry.md
+++ b/src/jee_based_entry.md
@@ -196,7 +196,7 @@ A learner entering through the qualifier route cannot switch to JEE-based entry 
 **Answer**: Learners who cleared JEE Main and are eligible for JEE Advanced within the allowed years can apply for the BS program under JEE-based entry.
 
 **Question**: When does the May 2026 qualifier application start?
-**Answer**: The May 2026 qualifier application has currently in-progress. The last date to apply is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.
+**Answer**: The May 2026 qualifier application is currently in-progress. The last date to apply is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.
 
 **Question**: When is the last date to apply for the May 2026 qualifier?
 **Answer**: The last date to apply for the May 2026 qualifier is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.

--- a/src/qualifier_eligibility.md
+++ b/src/qualifier_eligibility.md
@@ -161,7 +161,7 @@ Students from commerce or non-science streams can apply, provided they have stud
 If they pass the qualifier, they can join the program after completing Class 12.
 
 **Question**: When does the May 2026 qualifier application start?
-**Answer**: The May 2026 qualifier application has currently in-progress. The last date to apply is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.
+**Answer**: The May 2026 qualifier application is currently in-progress. The last date to apply is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.
 
 **Question**: When is the last date to apply for the May 2026 qualifier?
 **Answer**: The last date to apply for the May 2026 qualifier is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.

--- a/src/qualifier_results_and_validity.md
+++ b/src/qualifier_results_and_validity.md
@@ -184,7 +184,7 @@ Clearing the qualifier for:
 The learner must join within the validity period.
 
 **Question**: When does the May 2026 qualifier application start?
-**Answer**: The May 2026 qualifier application has currently in-progress. The last date to apply is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.
+**Answer**: The May 2026 qualifier application is currently in-progress. The last date to apply is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.
 
 **Question**: When is the last date to apply for the May 2026 qualifier?
 **Answer**: The last date to apply for the May 2026 qualifier is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.


### PR DESCRIPTION
This PR is expected to solve the immediate requirement that the BOT must answer at least the following two questions related to May 2026 qualifier. The goal was to solve the problem by making minimal changes to the code.

### The following questions are added:

**Question**:When does the May 2026 qualifier application starts?    
**Answer**:The May 2026 qualfier application has already in-progress. The last date to apply is May 30th, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.

**Question**: When does the last date to apply for the May 2026 qualifier?
**Answer**: The last date to apply for the May 2026 qualifier is May 30, 2026. You can visit "https://study.iitm.ac.in/ds" and click on "Apply Now" button to start your application process.

### 3 files modified:

**src/jee_based_entry.md
src/qualifier_eligibility.md
src/qualifier_results_and_validity.md**

### Why only these 3 files?

Because these 3 files have the highest chances of getting retrieved when a student asks the above two questions.