### PR TITLE
Merge `solveViaCloudBuild-my-prod-redeploy` into `my-prod-redeploy`

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -128,7 +128,44 @@ steps:
         echo "Waiting for services to be ready (Cloud Build cannot verify directly)..."
         sleep 60
 
-  # Step 5: Check if embedding is needed (based on tag name)
+  # Step 5: Reset stale Weaviate data only when the tag requests embedding
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'reset-weaviate-data'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+
+        echo "TAG_NAME: $TAG_NAME"
+        if ! echo "$TAG_NAME" | grep -qi "embed"; then
+          echo "Skipping Weaviate reset because this deployment is not an embed deployment"
+          exit 0
+        fi
+
+        echo "Resetting stale Weaviate data on the GCE VM..."
+        gcloud compute ssh iitm-ollama-vm \
+          --project="$PROJECT_ID" \
+          --zone=asia-south1-a \
+          --tunnel-through-iap \
+          --command='set -euo pipefail
+            cd /opt/iitm-chatbot
+            WEAVIATE_CONTAINER_ID="$(docker compose ps -q weaviate || true)"
+            if [ -n "$WEAVIATE_CONTAINER_ID" ]; then
+              echo "[remote] stopping weaviate container: $WEAVIATE_CONTAINER_ID"
+              docker compose stop weaviate
+            else
+              echo "[remote] weaviate container is not running; skipping stop"
+            fi
+            echo "[remote] removing stale weaviate_data"
+            sudo rm -rf weaviate_data
+            echo "[remote] recreating weaviate_data"
+            sudo mkdir weaviate_data
+            echo "[remote] starting weaviate"
+            docker compose up -d weaviate
+            echo "[remote] reset complete"'
+
+  # Step 6: Check if embedding is needed (based on tag name)
   - name: 'gcr.io/cloud-builders/git'
     id: 'check-embed-trigger'
     entrypoint: 'bash'
@@ -150,7 +187,7 @@ steps:
 
         echo "Embed mode: $$(cat /workspace/embed_mode.txt)"
 
-  # Step 6: Build embed image (only if src/ changed)
+  # Step 7: Build embed image (only if src/ changed)
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-embed'
     entrypoint: 'bash'
@@ -167,7 +204,7 @@ steps:
           -t gcr.io/$PROJECT_ID/iitm-embed:latest \
           -f Dockerfile.embed .
 
-  # Step 7: Build worker image
+  # Step 8: Build worker image
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-worker'
     args:
@@ -180,7 +217,7 @@ steps:
       - 'Dockerfile.worker'
       - '.'
 
-  # Step 8: Push embed image (only if src/ changed)
+  # Step 9: Push embed image (only if src/ changed)
   - name: 'gcr.io/cloud-builders/docker'
     id: 'push-embed'
     entrypoint: 'bash'
@@ -207,7 +244,7 @@ steps:
         fi
         docker push gcr.io/$PROJECT_ID/iitm-embed:latest
 
-  # Step 9: Push worker image
+  # Step 10: Push worker image
   - name: 'gcr.io/cloud-builders/docker'
     id: 'push-worker'
     args: ['push', 'gcr.io/$PROJECT_ID/iitm-chatbot-worker:$COMMIT_SHA']
@@ -216,7 +253,7 @@ steps:
     id: 'push-worker-latest'
     args: ['push', 'gcr.io/$PROJECT_ID/iitm-chatbot-worker:latest']
 
-  # Step 10: Create/Update Cloud Run Job for embedding (only if src/ changed)
+  # Step 11: Create/Update Cloud Run Job for embedding (only if src/ changed)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'create-embed-job'
     entrypoint: 'bash'
@@ -249,7 +286,7 @@ steps:
           --task-timeout=60m \
           --max-retries=1
 
-  # Step 11: Execute the embed job and stream logs (only if src/ changed)
+  # Step 12: Execute the embed job and stream logs (only if src/ changed)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'run-embed-job'
     entrypoint: 'bash'
@@ -298,7 +335,7 @@ steps:
           sleep 5
         done
 
-  # Step 12: Deploy Cloud Run service
+  # Step 13: Deploy Cloud Run service
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'deploy-cloudrun'
     entrypoint: 'bash'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -150,13 +150,8 @@ steps:
           --tunnel-through-iap \
           --command='set -euo pipefail
             cd /opt/iitm-chatbot
-            WEAVIATE_CONTAINER_ID="$(docker compose ps -q weaviate || true)"
-            if [ -n "$WEAVIATE_CONTAINER_ID" ]; then
-              echo "[remote] stopping weaviate container: $WEAVIATE_CONTAINER_ID"
-              docker compose stop weaviate
-            else
-              echo "[remote] weaviate container is not running; skipping stop"
-            fi
+            echo "[remote] stopping weaviate"
+            docker compose stop weaviate || true
             echo "[remote] removing stale weaviate_data"
             sudo rm -rf weaviate_data
             echo "[remote] recreating weaviate_data"


### PR DESCRIPTION
## Summary

This PR updates [cloudbuild.yaml](https://github.com/RishavT/iitmdocs/blob/solveViaCloudBuild-my-prod-redeploy/cloudbuild.yaml) to reset stale Weaviate data during embed deployments.

The main change is simple:

- if the tag name contains `embed`, Cloud Build resets `weaviate_data` on the GCE VM before the embed job runs
- if the tag does not contain `embed`, the reset step is skipped

This keeps normal deployments safe and only wipes Weaviate when the pipeline is already doing an embed run.

## Roles granted to service account

The Cloud Build service account i.e. `329264250413@cloudbuild.gserviceaccount.com` used for this flow has also been granted:

- `roles/iap.tunnelResourceAccessor`
- `roles/compute.osLogin`

## Why this change is needed

We saw repeated `leader not found` failures from Weaviate during the embed job. Restarting the VM did not fix it, so the stale Weaviate data directory needed to be cleared.

## What changed

- added a Cloud Build step to reset `weaviate_data` on `iitm-ollama-vm`
- made the reset step run only when `TAG_NAME` contains `embed`
- kept the step fail-fast so SSH or reset errors are visible in Cloud Build logs
- intentionally did not kept any backup of the previous weaviate data in this flow

## Files changed

- [cloudbuild.yaml](https://github.com/RishavT/iitmdocs/blob/solveViaCloudBuild-my-prod-redeploy/cloudbuild.yaml)
