### PR TITLE
modify-fallback-response-include-details-of-all-4-programs --> remove-LANG-tag-always-answer-in-english

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,10 @@ debug/
 ollama_data/
 tmp/
 weaviate_data/
-docs/
+docs/*
 !docs/chatbot-101.md
 !docs/chatbot-technicals.md
+!docs/program-contact-details.md
 
 # Any source pdf folders
 src_pdf/

--- a/docs/program-contact-details.md
+++ b/docs/program-contact-details.md
@@ -1,0 +1,35 @@
+# IITM BS Program Contact Details
+
+Use the program-specific contact below when a question is about a particular IITM BS program.
+
+---
+
+## Data Science and Applications
+
+**Email:** support@study.iitm.ac.in  
+**Contact:** +91-7850999966  
+**Website:** https://study.iitm.ac.in/ds
+
+---
+
+## Management and Data Science
+
+**Email:** support-mg@study.iitm.ac.in  
+**Contact:** +91-7850999966  
+**Website:** https://study.iitm.ac.in/mg/
+
+---
+
+## Electronic Systems
+
+**Email:** support-es@study.iitm.ac.in  
+**Contact:** +91-9711397993  
+**Website:** https://study.iitm.ac.in/es/
+
+---
+
+## Aeronautics and Space Technology
+
+**Email:** support-ae@study.iitm.ac.in  
+**Contact:** +91-9711397993  
+**Website:** https://study.iitm.ac.in/ae/

--- a/qa.test.js
+++ b/qa.test.js
@@ -47,6 +47,15 @@ describe("Welcome Message", () => {
   });
 });
 
+describe("Program Contact Details CTA", () => {
+  it("should route the program contact details link through the document viewer", () => {
+    expect(qaJs).toContain("PROGRAM_CONTACT_DETAILS_URL");
+    expect(qaJs).toContain("docs/program-contact-details.md");
+    expect(qaJs).toContain('class="ref-doc-link"');
+    expect(qaJs).toContain('data-name="program-contact-details.md"');
+  });
+});
+
 describe("Consent Overlay", () => {
   let dom;
   let document;

--- a/qa.test.js
+++ b/qa.test.js
@@ -52,7 +52,7 @@ describe("Program Contact Details CTA", () => {
     expect(qaJs).toContain("PROGRAM_CONTACT_DETAILS_URL");
     expect(qaJs).toContain("docs/program-contact-details.md");
     expect(qaJs).toContain('class="ref-doc-link"');
-    expect(qaJs).toContain('data-name="program-contact-details.md"');
+    expect(qaJs).toContain('data-name="program-contact-details"');
   });
 });
 

--- a/static/qa.js
+++ b/static/qa.js
@@ -118,11 +118,16 @@ function updateInputValidation() {
 questionInput.addEventListener("input", updateInputValidation);
 const marked = new Marked();
 
+const PROGRAM_CONTACT_DETAILS_URL = "https://github.com/RishavT/iitmdocs/blob/main/docs/program-contact-details.md";
+
 // Configure marked to open links in new window
 marked.use({
   renderer: {
     link(href, title, text) {
       const titleAttr = title ? ` title="${title}"` : "";
+      if (href === PROGRAM_CONTACT_DETAILS_URL) {
+        return `<a href="${href}"${titleAttr} class="ref-doc-link" data-name="program-contact-details.md">${text}</a>`;
+      }
       return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
     }
   }

--- a/static/qa.js
+++ b/static/qa.js
@@ -126,7 +126,7 @@ marked.use({
     link(href, title, text) {
       const titleAttr = title ? ` title="${title}"` : "";
       if (href === PROGRAM_CONTACT_DETAILS_URL) {
-        return `<a href="${href}"${titleAttr} class="ref-doc-link" data-name="program-contact-details.md">${text}</a>`;
+        return `<a href="${href}"${titleAttr} class="ref-doc-link" data-name="program-contact-details">${text}</a>`;
       }
       return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
     }

--- a/worker.js
+++ b/worker.js
@@ -112,10 +112,9 @@ const CORS_HEADERS = {
 // Standard English "can't answer" message with embedded contact info.
 const CANNOT_ANSWER_MESSAGES = {
   english: `I'm sorry, I don't have the information to answer that question right now. Please rephrase your question and try again. Please refer to the official IITM BS degree program website or contact support for more details. If this is an error - please report this response using the feedback option.
+  You can reach out to us at ${CONTACT_INFO.email} or call us at ${CONTACT_INFO.phone}.
 
-Need program-wise contacts? [View all program contact details](${PROGRAM_CONTACT_DETAILS_URL}).
-
-You can reach out to us at ${CONTACT_INFO.email} or call us at ${CONTACT_INFO.phone}.`,
+Need program-wise contacts? [View all program contact details](${PROGRAM_CONTACT_DETAILS_URL}).`,
 };
 
 // Standardized RAAHAT message for mental health referrals - single source of truth

--- a/worker.js
+++ b/worker.js
@@ -100,6 +100,8 @@ const CONTACT_INFO = {
   phone: '7850999966',
 };
 
+const PROGRAM_CONTACT_DETAILS_URL = "https://github.com/RishavT/iitmdocs/blob/main/docs/program-contact-details.md";
+
 // Centralized CORS policy - allows cross-origin embedding of chatbot
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -109,7 +111,11 @@ const CORS_HEADERS = {
 
 // Standard English "can't answer" message with embedded contact info.
 const CANNOT_ANSWER_MESSAGES = {
-  english: `I'm sorry, I don't have the information to answer that question right now. Please rephrase your question and try again. Please refer to the official IITM BS degree program website or contact support for more details. If this is an error - please report this response using the feedback option. You can reach out to us at ${CONTACT_INFO.email} or call us at ${CONTACT_INFO.phone}`,
+  english: `I'm sorry, I don't have the information to answer that question right now. Please rephrase your question and try again. Please refer to the official IITM BS degree program website or contact support for more details. If this is an error - please report this response using the feedback option.
+
+Need program-wise contacts? [View all program contact details](${PROGRAM_CONTACT_DETAILS_URL}).
+
+You can reach out to us at ${CONTACT_INFO.email} or call us at ${CONTACT_INFO.phone}.`,
 };
 
 // Standardized RAAHAT message for mental health referrals - single source of truth

--- a/worker.test.js
+++ b/worker.test.js
@@ -444,6 +444,12 @@ describe("CANNOT_ANSWER_MESSAGE content (via getCannotAnswerMessage)", () => {
     const message = getCannotAnswerMessage();
     expect(message).toContain("7850999966");
   });
+
+  it("should include a compact program contact details link", () => {
+    const message = getCannotAnswerMessage();
+    expect(message).toContain("[View all program contact details]");
+    expect(message).toContain("docs/program-contact-details.md");
+  });
 });
 
 describe("getCannotAnswerMessage()", () => {


### PR DESCRIPTION
## Summary

This PR updates the chatbot fallback flow so users who hit an unanswerable question can still quickly reach the right program-specific contact details. The overall goal is to keep fallback answers short, preserve the existing helpful support guidance, and give users a direct path to the four program contact pages.

## What changed

- worker.js
  - Added a dedicated `PROGRAM_CONTACT_DETAILS_URL` constant.
  - Shortened the fallback response and kept the existing support guidance intact.
  - Added a compact call-to-action link: “View all program contact details”.
  - Why: the fallback should remain readable in a small chat window while still directing users to the full contact information.

- static/qa.js
  - Added special handling for the program contact details link inside the markdown renderer.
  - That link now gets `ref-doc-link` behavior so it opens in the existing document viewer modal instead of a normal new tab.
  - Why: this keeps the fallback lightweight while letting users inspect the full contact document in-context.

- docs/program-contact-details.md
  - Added a new markdown document containing all four programs’ contact details:
    - email
    - phone number
    - website

- .gitignore
  - Updated the docs ignore rule so this specific markdown file can be tracked.

- worker.test.js
  - Added coverage for the fallback CTA and confirmed the message still contains the required support guidance.

- qa.test.js
  - Added coverage that the CTA is wired through the document viewer path.

**Why this is better**

- The fallback no longer tries to cram all program contact details into a small chat bubble.
- The full details are one click away.
- The experience is in-line with the existing document-viewer flow already used elsewhere in the chatbot.
- The response stays compact, which matters in the initial embedded chat window and on smaller screens.