### PR TITLE
modify-extractLanguage-function-to-return-english-only --> main

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -129,10 +129,11 @@ Please don't hesitate to contact them - that's what they're there for. You're no
  * @returns {string} - Detected language (lowercase), defaults to 'english'
  */
 function extractLanguage(rewrittenQuery) {
-  if (!rewrittenQuery) return 'english';
-  const match = rewrittenQuery.match(/\[LANG:(\w+)\]/i);
-  const lang = match ? match[1].toLowerCase() : 'english';
-  return SUPPORTED_LANGUAGES.includes(lang) ? lang : 'english';
+  return 'english'; // Default to English for now
+  // if (!rewrittenQuery) return 'english';
+  // const match = rewrittenQuery.match(/\[LANG:(\w+)\]/i);
+  // const lang = match ? match[1].toLowerCase() : 'english';
+  // return SUPPORTED_LANGUAGES.includes(lang) ? lang : 'english';
 }
 
 /**


### PR DESCRIPTION
In the PR, we have changed only the function `extractLanguage` so that whatever is the language of user's question, we always get answer in English.

**Here are some images from testing in LOCAL env:**

<img width="1321" height="115" alt="image" src="https://github.com/user-attachments/assets/5c11164e-9e9e-48fd-bf2a-fbbf814a394f" />
<img width="1266" height="454" alt="image" src="https://github.com/user-attachments/assets/5c590e83-cdea-4574-b0a2-eaeba009ce24" />
<img width="1335" height="357" alt="image" src="https://github.com/user-attachments/assets/41d8916f-0cdb-4a7c-818a-175114778653" />

