### PR TITLE
Change faqs to reflect sept term dates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     volumes:
       - ./src:/app/src:ro
       - ./embed.py:/app/embed.py:ro
+      - ./pg:/app/pg:ro
     profiles:
       - embed
     networks:

--- a/pg/seed/faqs.json
+++ b/pg/seed/faqs.json
@@ -1151,13 +1151,13 @@
   },
   {
     "topic_filename": "qualifier_results_and_validity.md",
-    "question": "When does the May 2026 qualifier application start?",
-    "answer": "The May 2026 qualifier application is currently in-progress. The last date to apply is May 30, 2026. You can visit \"https://study.iitm.ac.in/ds\" and click on \"Apply Now\" button to start your application process."
+    "question": "When does the September 2026 qualifier application start?",
+    "answer": "The September 2026 qualifier application is currently in-progress. The last date to apply is September 12, 2026. You can visit \"https://study.iitm.ac.in/ds\" and click on \"Apply Now\" button to start your application process."
   },
   {
     "topic_filename": "qualifier_results_and_validity.md",
-    "question": "When is the last date to apply for the May 2026 qualifier?",
-    "answer": "The last date to apply for the May 2026 qualifier is May 30, 2026. You can visit \"https://study.iitm.ac.in/ds\" and click on \"Apply Now\" button to start your application process."
+    "question": "When is the last date to apply for the September 2026 qualifier?",
+    "answer": "The last date to apply for the September 2026 qualifier is September 12, 2026. You can visit \"https://study.iitm.ac.in/ds\" and click on \"Apply Now\" button to start your application process."
   },
   {
     "topic_filename": "qualifier_results_and_validity.md",


### PR DESCRIPTION
# Summary:

- In `pg/seed/faqs.json`, the stale May 2026 qualifier FAQs were updated to September 2026:
  - Application cycle changed from `May 2026` to `September 2026`.
  - Deadline changed from `May 30, 2026` to `September 12, 2026`.

- In `docker-compose.yml`, the `embed` service now mounts `./pg` into the container:
  - `./pg:/app/pg:ro`

**Why:**

- The FAQ content needed to stop returning the expired May 2026 deadline.
- The `embed` container was previously using the old `pg/seed/faqs.json` copied into the Docker image at build time. Mounting `./pg` makes local seed-file changes visible when running `docker compose --profile local --profile embed run --rm embed`.