### PR TITLE
stop the rag pipeline if both weaviate & pg-faq-api return zero results

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1279,12 +1279,14 @@ async function searchWeaviate(query, limit, env) {
     try {
       data = JSON.parse(responseText);
     } catch (e) {
+      // Return the standard retrieval envelope so callers can log the real response failure.
       console.error('[DEBUG] Weaviate JSON parse error:', e.message);
       console.error('[DEBUG] Full response text:', responseText);
       return { items: [], error: `weaviate_response_malformed:${e.message}` };
     }
     console.log('[DEBUG] Weaviate JSON parsed successfully');
 
+    // A parsed value must still be a JSON object with the expected response shape.
     if (!data || typeof data !== "object" || Array.isArray(data)) {
       console.error('[DEBUG] Weaviate response is not a valid JSON object:', responseText);
       return { items: [], error: "weaviate_response_malformed:not_an_object" };
@@ -1304,6 +1306,7 @@ async function searchWeaviate(query, limit, env) {
     }
 
     console.log('[DEBUG] Weaviate returned', documents.length, 'documents');
+    // Keep usable documents even when GraphQL also reports partial errors.
     // Hybrid search returns 'score' (higher is better), not 'distance' (lower is better)
     return {
       items: documents.map((doc) => ({ ...doc, relevance: doc._additional?.score || 0 })),

--- a/worker.js
+++ b/worker.js
@@ -1264,6 +1264,11 @@ async function searchWeaviate(query, limit, env) {
     }
     console.log('[DEBUG] Weaviate JSON parsed successfully');
 
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      console.error('[DEBUG] Weaviate response is not a valid JSON object:', responseText);
+      return { items: [], error: "weaviate_response_malformed:not_an_object" };
+    }
+
     if (data.errors) {
       const errorMessage = data.errors.map((e) => e.message).join(", ");
       console.error('[DEBUG] Weaviate GraphQL error:', errorMessage);

--- a/worker.js
+++ b/worker.js
@@ -835,17 +835,17 @@ function formatDbFaqSuggestions(dbFaqs, language = "english") {
  * returns ["weaviate_documents_empty"].
  */
 function searchContextIssues(documentResult, faqResult) {
-  const documents = documentResult.items || [];
-  const dbFaqs = faqResult.items || [];
+  const documents = documentResult?.items || [];
+  const dbFaqs = faqResult?.items || [];
   const reasons = [];
 
-  if (documentResult.error) {
+  if (documentResult?.error) {
     reasons.push(documentResult.error);
   } else if (documents.length === 0) {
     reasons.push("weaviate_documents_empty");
   }
 
-  if (faqResult.error) {
+  if (faqResult?.error) {
     reasons.push(faqResult.error);
   } else if (dbFaqs.length === 0) {
     reasons.push("pg_faqs_empty");

--- a/worker.js
+++ b/worker.js
@@ -954,7 +954,7 @@ async function answer(request, env) {
 
           // Add "Did you mean?" suggestions from the Postgres FAQ DB (no LLM needed)
           const dbFaqResult = await fetchPgFaqs(question, 5, env);
-          const dbFaqs = dbFaqResult.items;
+          const dbFaqs = dbFaqResult?.items || [];
           rejectMessage += formatDbFaqSuggestions(dbFaqs, "english");
 
           logContext.response = rejectMessage;

--- a/worker.js
+++ b/worker.js
@@ -925,7 +925,7 @@ async function answer(request, env) {
     question: question,
     rewritten_query: null,
     query_source: "original", // "synonym", "llm", "original", or "rejected"
-    rejection_reason: null, // "prompt_injection", "fact_check_failed", "no_search_results", or null
+    rejection_reason: null, // "prompt_injection", "fact_check_failed", "no_search_results", "cannot_answer", or null
     documents: [],
     response: null,
     fact_check_passed: null,

--- a/worker.js
+++ b/worker.js
@@ -1190,9 +1190,12 @@ async function searchWeaviate(query, limit, env) {
     let queryVector;
     try {
       queryVector = await getOllamaEmbedding(query, ollamaUrl, embeddingModel, env);
+      if (!Array.isArray(queryVector)) {
+        throw new Error("Ollama embedding response is not an array");
+      }
     } catch (e) {
       console.error('[DEBUG] GCE query embedding error:', e?.message || String(e));
-      return { items: [], error: `weaviate_embedding_error:${e?.message || String(e)}` };
+      return { items: [], error: "weaviate_embedding_error:" + (e?.message || String(e)) };
     }
     const vectorStr = `[${queryVector.join(",")}]`;
 

--- a/worker.js
+++ b/worker.js
@@ -1273,10 +1273,15 @@ async function searchWeaviate(query, limit, env) {
 
     const documents = data.data?.Get?.Document || [];
     let graphqlError = null;
-    if (Array.isArray(data.errors) && data.errors.length) {
-      const errorMessage = data.errors.map((e) => e.message).join(", ");
-      console.error('[ERROR] Weaviate GraphQL error:', errorMessage);
-      graphqlError = `weaviate_graphql_error:${errorMessage}`;
+    if (data.errors !== undefined) {
+      if (!Array.isArray(data.errors)) {
+        console.error('[ERROR] Weaviate response has malformed errors:', data.errors);
+        graphqlError = "weaviate_response_malformed:errors_not_array";
+      } else if (data.errors.length) {
+        const errorMessage = data.errors.map((error) => error?.message || String(error)).join(", ");
+        console.error('[ERROR] Weaviate GraphQL error:', errorMessage);
+        graphqlError = `weaviate_graphql_error:${errorMessage}`;
+      }
     }
 
     console.log('[DEBUG] Weaviate returned', documents.length, 'documents');

--- a/worker.js
+++ b/worker.js
@@ -656,7 +656,20 @@ Examples:
 }
 
 // Export functions for testing
-export { handleFeedback, structuredLog, findSynonymMatch, extractLanguage, getCannotAnswerMessage, SUPPORTED_LANGUAGES, CONTACT_INFO, sanitizeQuery, rewriteQueryWithSource };
+export {
+  handleFeedback,
+  structuredLog,
+  findSynonymMatch,
+  extractLanguage,
+  getCannotAnswerMessage,
+  SUPPORTED_LANGUAGES,
+  CONTACT_INFO,
+  sanitizeQuery,
+  rewriteQueryWithSource,
+  fetchPgFaqs,
+  searchContextIssues,
+  searchWeaviate,
+};
 
 export default {
   async fetch(request, env) {

--- a/worker.js
+++ b/worker.js
@@ -6,9 +6,11 @@
 // 2. If the question is out of scope, return a rejection message with FAQ hints.
 // 3. Remove the language tag from the rewritten query.
 // 4. Search Weaviate for document chunks, then search the PG FAQ API.
-// 5. Build the answer from the user's question, matching documents, and matching FAQs.
+// 5. If both searches return no usable context, stop with the standard cannot-answer message.
+// 6. Build the answer from the user's question, matching documents, and matching FAQs.
 // Example: "How do I reset my password?" becomes a clean search query, then the
 // document search and FAQ search provide context before the final answer is made.
+// If both searches fail or return nothing, no answer is generated.
 //
 // Project terms:
 // - Weaviate documents: indexed document chunks used as long-form context.
@@ -792,13 +794,17 @@ async function fetchPgFaqs(query, k, env) {
     if (!response.ok) {
       const text = await response.text();
       console.error("[DEBUG] PG FAQ API /search failed:", response.status, text);
-      return [];
+      return { items: [], error: `pg_faq_api_error:${response.status}` };
     }
     const data = await response.json();
-    return Array.isArray(data?.results) ? data.results : [];
+    if (!Array.isArray(data?.results)) {
+      console.error("[DEBUG] PG FAQ API /search returned malformed results");
+      return { items: [], error: "pg_faq_response_malformed" };
+    }
+    return { items: data.results, error: null };
   } catch (e) {
     console.error("[DEBUG] PG FAQ API /search error:", e?.message || String(e));
-    return [];
+    return { items: [], error: `pg_faq_fetch_error:${e?.message || String(e)}` };
   }
 }
 
@@ -818,6 +824,34 @@ function formatDbFaqSuggestions(dbFaqs, language = "english") {
     .map((faq, i) => `${i + 1}. ${faq.question} [FAQID:${faq.id}]`)
     .join("\n");
   return `\n\n${header}\n\n${suggestions}`;
+}
+
+/**
+ * Returns retrieval problems so logs show empty results or service failures.
+ * Called after Weaviate and PG FAQ API finish, before answer generation.
+ *
+ * Example:
+ * searchContextIssues({ items: [] }, { items: [{ id: 7 }] })
+ * returns ["weaviate_documents_empty"].
+ */
+function searchContextIssues(documentResult, faqResult) {
+  const documents = documentResult.items || [];
+  const dbFaqs = faqResult.items || [];
+  const reasons = [];
+
+  if (documentResult.error) {
+    reasons.push(documentResult.error);
+  } else if (documents.length === 0) {
+    reasons.push("weaviate_documents_empty");
+  }
+
+  if (faqResult.error) {
+    reasons.push(faqResult.error);
+  } else if (dbFaqs.length === 0) {
+    reasons.push("pg_faqs_empty");
+  }
+
+  return reasons;
 }
 
 /**
@@ -891,7 +925,7 @@ async function answer(request, env) {
     question: question,
     rewritten_query: null,
     query_source: "original", // "synonym", "llm", "original", or "rejected"
-    rejection_reason: null, // "prompt_injection", "fact_check_failed", or null
+    rejection_reason: null, // "prompt_injection", "fact_check_failed", "no_search_results", or null
     documents: [],
     response: null,
     fact_check_passed: null,
@@ -919,7 +953,8 @@ async function answer(request, env) {
           let rejectMessage = getCannotAnswerMessage("english");
 
           // Add "Did you mean?" suggestions from the Postgres FAQ DB (no LLM needed)
-          const dbFaqs = await fetchPgFaqs(question, 5, env);
+          const dbFaqResult = await fetchPgFaqs(question, 5, env);
+          const dbFaqs = dbFaqResult.items;
           rejectMessage += formatDbFaqSuggestions(dbFaqs, "english");
 
           logContext.response = rejectMessage;
@@ -944,8 +979,10 @@ async function answer(request, env) {
         console.log('[DEBUG] Clean query for search:', cleanQuery);
 
         // Search Weaviate for relevant documents using clean query (without language tag)
-        const documents = await searchWeaviate(cleanQuery, numDocs, env);
-        const dbFaqs = await fetchPgFaqs(cleanQuery, 5, env);
+        const documentResult = await searchWeaviate(cleanQuery, numDocs, env);
+        const faqResult = await fetchPgFaqs(cleanQuery, 5, env);
+        const documents = documentResult.items;
+        const dbFaqs = faqResult.items;
 
         // Log document metadata (not full content)
         logContext.documents = (documents || []).map((doc) => ({
@@ -956,6 +993,33 @@ async function answer(request, env) {
           id: faq.id,
           cosine_similarity: faq.cosine_similarity,
         }));
+
+        const searchIssues = searchContextIssues(documentResult, faqResult);
+        if (searchIssues.length) {
+          logContext.search_result_causes = searchIssues;
+        }
+
+        if (!documents.length && !dbFaqs.length) {
+          const message = getCannotAnswerMessage(detectedLanguage);
+          logContext.rejection_reason = "no_search_results";
+          logContext.response = message;
+          logContext.latency_ms = Date.now() - startTime;
+
+          console.log("[DEBUG] Both searches returned no usable context:", searchIssues.join(","));
+
+          const fallbackResponse = createSSEResponse(message, { rejected: true });
+          await fallbackResponse.body.pipeTo(
+            new WritableStream({
+              write: (chunk) => controller.enqueue(chunk),
+              close: () => {
+                logDuration(env, "total_query", Date.now() - startTime);
+                structuredLog("INFO", "conversation_turn", logContext);
+                controller.close();
+              },
+            }),
+          );
+          return;
+        }
 
         // Stream documents first (single enqueue)
         if (documents?.length) {
@@ -1075,9 +1139,10 @@ async function searchWeaviate(query, limit, env) {
   console.log('[DEBUG] Deployment mode:', deploymentMode);
 
   if (deploymentMode !== "local" && deploymentMode !== "gce") {
-    throw new Error(
-      `Unsupported DEPLOYMENT_MODE='${deploymentMode}'. Supported values: local, gce.`
-    );
+    return {
+      items: [],
+      error: `weaviate_config_error:unsupported_DEPLOYMENT_MODE_${deploymentMode}`, // A Weaviate configuration problem should be logged as a retrieval cause. It should not crash the whole request before PG FAQ has a chance to return context.
+    };
   }
 
   // Configure Weaviate URL and headers based on mode
@@ -1094,7 +1159,7 @@ async function searchWeaviate(query, limit, env) {
     // GCE mode: connect to remote Weaviate on GCE VM
     weaviateUrl = env.GCE_WEAVIATE_URL;
     if (!weaviateUrl) {
-      throw new Error("GCE_WEAVIATE_URL is required for DEPLOYMENT_MODE=gce");
+      return { items: [], error: "weaviate_config_error:missing_GCE_WEAVIATE_URL" }; // This makes the failure visible in `search_result_causes` and lets the pipeline continue if PG FAQ has usable context.
     }
     console.log('[DEBUG] Using GCE Weaviate at:', weaviateUrl);
   }
@@ -1119,10 +1184,16 @@ async function searchWeaviate(query, limit, env) {
     console.log('[DEBUG] GCE query embedding config:', { ollamaUrl, embeddingModel });
 
     if (!ollamaUrl) {
-      throw new Error("GCE_OLLAMA_URL is required for DEPLOYMENT_MODE=gce");
+      return { items: [], error: "weaviate_config_error:missing_GCE_OLLAMA_URL" }; // In GCE mode, Weaviate search needs an Ollama embedding first. If that configuration is missing, the issue is now logged as a Weaviate retrieval cause instead of throwing error immediately.
     }
 
-    const queryVector = await getOllamaEmbedding(query, ollamaUrl, embeddingModel, env);
+    let queryVector;
+    try {
+      queryVector = await getOllamaEmbedding(query, ollamaUrl, embeddingModel, env);
+    } catch (e) {
+      console.error('[DEBUG] GCE query embedding error:', e?.message || String(e));
+      return { items: [], error: `weaviate_embedding_error:${e?.message || String(e)}` };
+    }
     const vectorStr = `[${queryVector.join(",")}]`;
 
     // Use hybrid search combining BM25 keyword search with vector similarity
@@ -1161,34 +1232,52 @@ async function searchWeaviate(query, limit, env) {
     }`;
   }
 
-  const weaviateGraphqlSearchStartTime = Date.now();
-  const response = await fetch(`${weaviateUrl}/v1/graphql`, {
-    method: "POST",
-    headers: embeddingHeaders,
-    body: JSON.stringify({ query: graphqlQuery }),
-  });
-  logDuration(env, "weaviate_graphql_search", Date.now() - weaviateGraphqlSearchStartTime);
-
-  console.log('[DEBUG] Weaviate response received, status:', response.status);
-  const responseText = await response.text();
-  console.log('[DEBUG] Weaviate response text length:', responseText.length);
-  console.log('[DEBUG] Weaviate response preview:', responseText.substring(0, 200));
-
-  let data;
   try {
-    data = JSON.parse(responseText);
-    console.log('[DEBUG] Weaviate JSON parsed successfully');
-  } catch (e) {
-    console.error('[DEBUG] Weaviate JSON parse error:', e.message);
-    console.error('[DEBUG] Full response text:', responseText);
-    throw new Error(`Failed to parse Weaviate response: ${e.message}`);
-  }
-  if (data.errors) throw new Error(`Weaviate error: ${data.errors.map((e) => e.message).join(", ")}`);
+    const weaviateGraphqlSearchStartTime = Date.now();
+    const response = await fetch(`${weaviateUrl}/v1/graphql`, {
+      method: "POST",
+      headers: embeddingHeaders,
+      body: JSON.stringify({ query: graphqlQuery }),
+    });
+    logDuration(env, "weaviate_graphql_search", Date.now() - weaviateGraphqlSearchStartTime);
 
-  const documents = data.data?.Get?.Document || [];
-  console.log('[DEBUG] Weaviate returned', documents.length, 'documents');
-  // Hybrid search returns 'score' (higher is better), not 'distance' (lower is better)
-  return documents.map((doc) => ({ ...doc, relevance: doc._additional?.score || 0 }));
+    console.log('[DEBUG] Weaviate response received, status:', response.status);
+    const responseText = await response.text();
+    console.log('[DEBUG] Weaviate response text length:', responseText.length);
+    console.log('[DEBUG] Weaviate response preview:', responseText.substring(0, 200));
+
+    if (!response.ok) {
+      console.error('[DEBUG] Weaviate HTTP error:', response.status, responseText);
+      return { items: [], error: `weaviate_api_error:${response.status}` };
+    }
+
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch (e) {
+      console.error('[DEBUG] Weaviate JSON parse error:', e.message);
+      console.error('[DEBUG] Full response text:', responseText);
+      return { items: [], error: `weaviate_response_malformed:${e.message}` };
+    }
+    console.log('[DEBUG] Weaviate JSON parsed successfully');
+
+    if (data.errors) {
+      const errorMessage = data.errors.map((e) => e.message).join(", ");
+      console.error('[DEBUG] Weaviate GraphQL error:', errorMessage);
+      return { items: [], error: `weaviate_graphql_error:${errorMessage}` };
+    }
+
+    const documents = data.data?.Get?.Document || [];
+    console.log('[DEBUG] Weaviate returned', documents.length, 'documents');
+    // Hybrid search returns 'score' (higher is better), not 'distance' (lower is better)
+    return {
+      items: documents.map((doc) => ({ ...doc, relevance: doc._additional?.score || 0 })),
+      error: null,
+    };
+  } catch (e) {
+    console.error('[DEBUG] Weaviate search error:', e?.message || String(e));
+    return { items: [], error: `weaviate_fetch_error:${e?.message || String(e)}` };
+  }
 }
 
 async function generateAnswer(question, documents, dbFaqs, history, env, logContext = null, language = 'english') {

--- a/worker.js
+++ b/worker.js
@@ -1192,8 +1192,10 @@ async function searchWeaviate(query, limit, env) {
     let queryVector;
     try {
       queryVector = await getOllamaEmbedding(query, ollamaUrl, embeddingModel, env);
-      if (!Array.isArray(queryVector)) {
-        throw new Error("Ollama embedding response is not an array");
+      const hasValidEmbedding =
+        Array.isArray(queryVector) && queryVector.length > 0 && queryVector.every(Number.isFinite);
+      if (!hasValidEmbedding) {
+        throw new Error("Ollama embedding response is not a non-empty array of finite numbers");
       }
     } catch (e) {
       console.error('[DEBUG] GCE query embedding error:', e?.message || String(e));

--- a/worker.js
+++ b/worker.js
@@ -981,8 +981,8 @@ async function answer(request, env) {
         // Search Weaviate for relevant documents using clean query (without language tag)
         const documentResult = await searchWeaviate(cleanQuery, numDocs, env);
         const faqResult = await fetchPgFaqs(cleanQuery, 5, env);
-        const documents = documentResult.items;
-        const dbFaqs = faqResult.items;
+        const documents = documentResult?.items || [];
+        const dbFaqs = faqResult?.items || [];
 
         // Log document metadata (not full content)
         logContext.documents = (documents || []).map((doc) => ({

--- a/worker.js
+++ b/worker.js
@@ -997,12 +997,14 @@ async function answer(request, env) {
         const searchIssues = searchContextIssues(documentResult, faqResult);
         if (searchIssues.length) {
           logContext.search_result_causes = searchIssues;
+          logContext.error = searchIssues.join("; ");
         }
 
         if (!documents.length && !dbFaqs.length) {
           const message = getCannotAnswerMessage(detectedLanguage);
           logContext.rejection_reason = "no_search_results";
           logContext.response = message;
+          logContext.error = searchIssues.join("; ") || "no_search_results";
           logContext.latency_ms = Date.now() - startTime;
 
           console.log("[DEBUG] Both searches returned no usable context:", searchIssues.join(","));
@@ -1013,7 +1015,7 @@ async function answer(request, env) {
               write: (chunk) => controller.enqueue(chunk),
               close: () => {
                 logDuration(env, "total_query", Date.now() - startTime);
-                structuredLog("INFO", "conversation_turn", logContext);
+                structuredLog("ERROR", "conversation_turn", logContext);
                 controller.close();
               },
             }),
@@ -1065,7 +1067,7 @@ async function answer(request, env) {
               // Log the conversation when stream closes
               logContext.latency_ms = Date.now() - startTime;
               logDuration(env, "total_query", Date.now() - startTime);
-              structuredLog("INFO", "conversation_turn", logContext);
+              structuredLog(logContext.error ? "ERROR" : "INFO", "conversation_turn", logContext);
               controller.close();
             },
             abort: (reason) => {

--- a/worker.js
+++ b/worker.js
@@ -1271,18 +1271,19 @@ async function searchWeaviate(query, limit, env) {
       return { items: [], error: "weaviate_response_malformed:not_an_object" };
     }
 
-    if (data.errors) {
+    const documents = data.data?.Get?.Document || [];
+    let graphqlError = null;
+    if (Array.isArray(data.errors) && data.errors.length) {
       const errorMessage = data.errors.map((e) => e.message).join(", ");
-      console.error('[DEBUG] Weaviate GraphQL error:', errorMessage);
-      return { items: [], error: `weaviate_graphql_error:${errorMessage}` };
+      console.error('[ERROR] Weaviate GraphQL error:', errorMessage);
+      graphqlError = `weaviate_graphql_error:${errorMessage}`;
     }
 
-    const documents = data.data?.Get?.Document || [];
     console.log('[DEBUG] Weaviate returned', documents.length, 'documents');
     // Hybrid search returns 'score' (higher is better), not 'distance' (lower is better)
     return {
       items: documents.map((doc) => ({ ...doc, relevance: doc._additional?.score || 0 })),
-      error: null,
+      error: graphqlError,
     };
   } catch (e) {
     console.error('[DEBUG] Weaviate search error:', e?.message || String(e));

--- a/worker.js
+++ b/worker.js
@@ -1022,17 +1022,14 @@ async function answer(request, env) {
 
           console.log("[DEBUG] Both searches returned no usable context:", searchIssues.join(","));
 
-          const fallbackResponse = createSSEResponse(message, { rejected: true });
-          await fallbackResponse.body.pipeTo(
-            new WritableStream({
-              write: (chunk) => controller.enqueue(chunk),
-              close: () => {
-                logDuration(env, "total_query", Date.now() - startTime);
-                structuredLog("ERROR", "conversation_turn", logContext);
-                controller.close();
-              },
-            }),
-          );
+          const sseData = `data: ${JSON.stringify({
+            choices: [{ delta: { content: message } }],
+            rejected: true,
+          })}\n\ndata: [DONE]\n\n`;
+          controller.enqueue(encoder.encode(sseData));
+          logDuration(env, "total_query", Date.now() - startTime);
+          structuredLog("ERROR", "conversation_turn", logContext);
+          controller.close();
           return;
         }
 

--- a/worker.js
+++ b/worker.js
@@ -1013,7 +1013,7 @@ async function answer(request, env) {
           logContext.error = searchIssues.join("; ");
         }
 
-        if (!documents.length && !dbFaqs.length) {
+        if (!documents.length && !dbFaqs.length) { // No usable context from either source
           const message = getCannotAnswerMessage(detectedLanguage);
           logContext.rejection_reason = "no_search_results";
           logContext.response = message;
@@ -1028,7 +1028,7 @@ async function answer(request, env) {
           })}\n\ndata: [DONE]\n\n`;
           controller.enqueue(encoder.encode(sseData));
           logDuration(env, "total_query", Date.now() - startTime);
-          structuredLog("ERROR", "conversation_turn", logContext);
+          structuredLog("CRITICAL", "conversation_turn", logContext);
           controller.close();
           return;
         }
@@ -1077,7 +1077,14 @@ async function answer(request, env) {
               // Log the conversation when stream closes
               logContext.latency_ms = Date.now() - startTime;
               logDuration(env, "total_query", Date.now() - startTime);
-              structuredLog(logContext.error ? "ERROR" : "INFO", "conversation_turn", logContext);
+
+              // Retrieval issues are critical, while unrelated errors stay ERROR and successful turns stay INFO.
+              const severity = searchIssues.length
+                ? "CRITICAL"
+                : logContext.error
+                  ? "ERROR"
+                  : "INFO";
+              structuredLog(severity, "conversation_turn", logContext);
               controller.close();
             },
             abort: (reason) => {

--- a/worker.test.js
+++ b/worker.test.js
@@ -12,6 +12,7 @@ import {
   searchContextIssues,
   searchWeaviate,
 } from "./worker.js";
+import worker from "./worker.js";
 
 // Mock console.log to capture structured logs
 const mockLogs = [];
@@ -1287,6 +1288,131 @@ describe("Retrieval result envelopes", () => {
     ).resolves.toEqual({
       items: [],
       error: "weaviate_embedding_error:Ollama unavailable",
+    });
+  });
+});
+
+describe("POST /answer retrieval control flow", () => {
+  const routeEnv = {
+    DEPLOYMENT_MODE: "local",
+    PG_FAQ_API_URL: "http://pg-faq-api:8000",
+    CHAT_API_ENDPOINT: "https://chat.test/completions",
+  };
+
+  beforeEach(() => {
+    mockLogs.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function getConversationLog() {
+    return mockLogs
+      .map(([value]) => {
+        try {
+          return JSON.parse(value);
+        } catch {
+          return null;
+        }
+      })
+      .find((entry) => entry?.message === "conversation_turn");
+  }
+
+  function answerRequest() {
+    return {
+      method: "POST",
+      url: "https://worker.test/answer",
+      json: async () => ({ q: "fees" }),
+    };
+  }
+
+  function getChatRequests() {
+    return global.fetch.mock.calls
+      .filter(([url]) => url === routeEnv.CHAT_API_ENDPOINT)
+      .map(([, options]) => JSON.parse(options.body));
+  }
+
+  it("rejects and skips answer generation when both retrieval sources fail", async () => {
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes("/v1/graphql")) {
+        return Promise.resolve({ ok: false, status: 503, text: async () => "unavailable" });
+      }
+      if (url === routeEnv.CHAT_API_ENDPOINT) {
+        return Promise.resolve({ ok: false, status: 503, text: async () => "unavailable" });
+      }
+      return Promise.resolve({ ok: false, status: 503, text: async () => "unavailable" });
+    });
+
+    const response = await worker.fetch(answerRequest(), routeEnv);
+    const body = await response.text();
+    const conversationLog = getConversationLog();
+
+    expect(body).toContain('"rejected":true');
+    expect(body).toContain("data: [DONE]");
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(getChatRequests()).toHaveLength(1);
+    expect(getChatRequests()[0].stream).toBeUndefined();
+    expect(getChatRequests().filter((request) => request.stream === false)).toHaveLength(0);
+    expect(conversationLog).toMatchObject({
+      severity: "CRITICAL",
+      rejection_reason: "no_search_results",
+      error: "weaviate_api_error:503; pg_faq_api_error:503",
+    });
+  });
+
+  it("continues to answer when one retrieval source provides context", async () => {
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes("/v1/graphql")) {
+        return Promise.resolve({
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              data: {
+                Get: {
+                  Document: [{ filename: "fees.md", content: "Programme fees are listed here.", _additional: { score: 0.9 } }],
+                },
+              },
+            }),
+        });
+      }
+      if (url.includes("/search")) {
+        return Promise.resolve({ ok: true, json: async () => ({ results: [] }) });
+      }
+      if (url === routeEnv.CHAT_API_ENDPOINT) {
+        const chatCallNumber = global.fetch.mock.calls.filter(([callUrl]) => callUrl === routeEnv.CHAT_API_ENDPOINT).length;
+        const contentByCall = {
+          1: "fees fee structure [LANG:english]",
+          2: "Programme fees are listed here.",
+          3: '{"approved":"YES","incorrect":[]}',
+        };
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            choices: [
+              {
+                message: {
+                  content: contentByCall[chatCallNumber],
+                },
+              },
+            ],
+          }),
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const response = await worker.fetch(answerRequest(), routeEnv);
+    const body = await response.text();
+    const conversationLog = getConversationLog();
+
+    expect(body).toContain("Programme fees are listed here.");
+    expect(body).not.toContain('"rejected":true');
+    expect(getChatRequests()).toHaveLength(3);
+    expect(getChatRequests().filter((request) => request.stream === false)).toHaveLength(2);
+    expect(conversationLog).toMatchObject({
+      severity: "CRITICAL",
+      error: "pg_faqs_empty",
     });
   });
 });

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { handleFeedback, structuredLog, findSynonymMatch, extractLanguage, getCannotAnswerMessage, SUPPORTED_LANGUAGES, CONTACT_INFO, sanitizeQuery } from "./worker.js";
+import {
+  handleFeedback,
+  structuredLog,
+  findSynonymMatch,
+  extractLanguage,
+  getCannotAnswerMessage,
+  SUPPORTED_LANGUAGES,
+  CONTACT_INFO,
+  sanitizeQuery,
+  fetchPgFaqs,
+  searchContextIssues,
+  searchWeaviate,
+} from "./worker.js";
 
 // Mock console.log to capture structured logs
 const mockLogs = [];
@@ -1115,6 +1127,166 @@ Tags: qualifier, exam`,
       const result = await getFAQSuggestions("qualifier clearing", env, "english");
 
       expect(result).toContain("What should I do after clearing the qualifier?");
+    });
+  });
+});
+
+describe("Retrieval result envelopes", () => {
+  const localEnv = { DEPLOYMENT_MODE: "local", PG_FAQ_API_URL: "http://pg-faq-api:8000" };
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("keeps retrieval errors ahead of empty-result causes", () => {
+    expect(
+      searchContextIssues(
+        { items: [], error: "weaviate_api_error:503" },
+        { items: [], error: null },
+      ),
+    ).toEqual(["weaviate_api_error:503", "pg_faqs_empty"]);
+  });
+
+  it("reports empty results when both services succeed without matches", () => {
+    expect(searchContextIssues({ items: [], error: null }, { items: [], error: null })).toEqual([
+      "weaviate_documents_empty",
+      "pg_faqs_empty",
+    ]);
+  });
+
+  it("reports no issues when either source provides context", () => {
+    expect(searchContextIssues({ items: [{ filename: "fees.md" }], error: null }, { items: [], error: null })).toEqual([
+      "pg_faqs_empty",
+    ]);
+  });
+
+  it("returns PG FAQ results on a successful response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ id: 1, question: "What are the fees?" }] }),
+    });
+
+    await expect(fetchPgFaqs("fees", 5, localEnv)).resolves.toEqual({
+      items: [{ id: 1, question: "What are the fees?" }],
+      error: null,
+    });
+  });
+
+  it("returns a PG FAQ HTTP error envelope", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "unavailable",
+    });
+
+    await expect(fetchPgFaqs("fees", 5, localEnv)).resolves.toEqual({
+      items: [],
+      error: "pg_faq_api_error:503",
+    });
+  });
+
+  it("returns a PG FAQ malformed-response envelope", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: "not an array" }),
+    });
+
+    await expect(fetchPgFaqs("fees", 5, localEnv)).resolves.toEqual({
+      items: [],
+      error: "pg_faq_response_malformed",
+    });
+  });
+
+  it("returns a PG FAQ fetch-error envelope", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+
+    await expect(fetchPgFaqs("fees", 5, localEnv)).resolves.toEqual({
+      items: [],
+      error: "pg_faq_fetch_error:network down",
+    });
+  });
+
+  it("preserves Weaviate documents from a partial GraphQL response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          data: { Get: { Document: [{ filename: "fees.md", _additional: { score: 0.8 } }] } },
+          errors: [{ message: "one optional field failed" }],
+        }),
+    });
+
+    await expect(searchWeaviate("fees", 2, localEnv)).resolves.toEqual({
+      items: [{ filename: "fees.md", _additional: { score: 0.8 }, relevance: 0.8 }],
+      error: "weaviate_graphql_error:one optional field failed",
+    });
+  });
+
+  it("reports a malformed Weaviate errors field without throwing", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ errors: "upstream unavailable" }),
+    });
+
+    await expect(searchWeaviate("fees", 2, localEnv)).resolves.toEqual({
+      items: [],
+      error: "weaviate_response_malformed:errors_not_array",
+    });
+  });
+
+  it("returns a Weaviate HTTP error envelope", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "unavailable",
+    });
+
+    await expect(searchWeaviate("fees", 2, localEnv)).resolves.toEqual({
+      items: [],
+      error: "weaviate_api_error:503",
+    });
+  });
+
+  it("returns a Weaviate malformed-JSON envelope", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => "not json" });
+
+    const result = await searchWeaviate("fees", 2, localEnv);
+
+    expect(result.items).toEqual([]);
+    expect(result.error).toMatch(/^weaviate_response_malformed:/);
+  });
+
+  it("returns an unsupported deployment-mode envelope", async () => {
+    await expect(searchWeaviate("fees", 2, { DEPLOYMENT_MODE: "unknown" })).resolves.toEqual({
+      items: [],
+      error: "weaviate_config_error:unsupported_DEPLOYMENT_MODE_unknown",
+    });
+  });
+
+  it("returns a missing GCE configuration envelope", async () => {
+    await expect(searchWeaviate("fees", 2, { DEPLOYMENT_MODE: "gce" })).resolves.toEqual({
+      items: [],
+      error: "weaviate_config_error:missing_GCE_WEAVIATE_URL",
+    });
+  });
+
+  it("returns an embedding error when Ollama fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Ollama unavailable"));
+
+    await expect(
+      searchWeaviate("fees", 2, {
+        DEPLOYMENT_MODE: "gce",
+        GCE_WEAVIATE_URL: "http://weaviate:8080",
+        GCE_OLLAMA_URL: "http://ollama:11434",
+      }),
+    ).resolves.toEqual({
+      items: [],
+      error: "weaviate_embedding_error:Ollama unavailable",
     });
   });
 });


### PR DESCRIPTION
## PR Summary

This PR updates `worker.js` so the answer pipeline stops early only when both retrieval sources return no usable context:

- Weaviate returns no documents or an error
- PG FAQ API returns no FAQs or an error

If either source still provides usable context, the pipeline continues with answer generation and fact-checking. Retrieval issues are recorded in `logContext.search_result_causes`.

Logging severity now reflects retrieval health:

- both sources unavailable or empty: `CRITICAL`
- one source unavailable or empty: `CRITICAL`
- unrelated request errors: `ERROR`
- successful retrieval: `INFO`

Weaviate GraphQL partial responses preserve returned documents while still recording GraphQL errors. Malformed error payloads and invalid Ollama embeddings are handled defensively.

## Why

Earlier, retrieval failures could crash the request or be indistinguishable from normal empty results. This change:

- captures service failures as structured errors
- records empty retrieval results explicitly
- preserves usable context when only one source fails
- avoids asking the LLM to answer when no context is available
- keeps fact-checking skipped only when answer generation is skipped
- makes serious retrieval degradation visible through `CRITICAL` logs

## Local Testing

Tested the retrieval envelope and error-handling paths with focused Vitest tests:

- both sources empty
- one source empty while the other has context
- PG FAQ API failures and malformed responses
- Weaviate HTTP, JSON, configuration, and embedding failures
- Weaviate GraphQL partial success
- malformed non-array GraphQL errors

Also verified `worker.js` syntax with `node --check`.