### PR TITLE
Fix Cloud Build Weaviate reset Docker permission error

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -156,6 +156,8 @@ steps:
             sudo rm -rf weaviate_data
             echo "[remote] recreating weaviate_data"
             sudo mkdir weaviate_data
+            echo "[remote] allowing weaviate to write data"
+            sudo chown -R 1000:1000 weaviate_data
             echo "[remote] starting weaviate"
             sudo docker compose up -d weaviate
             echo "[remote] reset complete"'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -151,13 +151,13 @@ steps:
           --command='set -euo pipefail
             cd /opt/iitm-chatbot
             echo "[remote] stopping weaviate"
-            docker compose stop weaviate || true
+            sudo docker compose stop weaviate || true
             echo "[remote] removing stale weaviate_data"
             sudo rm -rf weaviate_data
             echo "[remote] recreating weaviate_data"
             sudo mkdir weaviate_data
             echo "[remote] starting weaviate"
-            docker compose up -d weaviate
+            sudo docker compose up -d weaviate
             echo "[remote] reset complete"'
 
   # Step 6: Check if embedding is needed (based on tag name)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -151,15 +151,15 @@ steps:
           --command='set -euo pipefail
             cd /opt/iitm-chatbot
             echo "[remote] stopping weaviate"
-            sudo docker compose stop weaviate || true
+            sudo -n docker compose stop weaviate || true
             echo "[remote] removing stale weaviate_data"
             sudo rm -rf weaviate_data
             echo "[remote] recreating weaviate_data"
             sudo mkdir weaviate_data
             echo "[remote] allowing weaviate to write data"
-            sudo chown -R 1000:1000 weaviate_data
+            sudo -n chown -R 1000:1000 weaviate_data
             echo "[remote] starting weaviate"
-            sudo docker compose up -d weaviate
+            sudo -n docker compose up -d weaviate
             echo "[remote] reset complete"'
 
   # Step 6: Check if embedding is needed (based on tag name)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -151,13 +151,13 @@ steps:
           --command='set -euo pipefail
             cd /opt/iitm-chatbot
             echo "[remote] stopping weaviate"
-            sudo -n docker compose stop weaviate || true
+            sudo -n docker compose stop weaviate
             echo "[remote] removing stale weaviate_data"
-            sudo rm -rf weaviate_data
+            sudo -n rm -rf -- weaviate_data
             echo "[remote] recreating weaviate_data"
-            sudo mkdir weaviate_data
+            sudo -n mkdir weaviate_data
             echo "[remote] allowing weaviate to write data"
-            sudo -n chown -R 1000:1000 weaviate_data
+            sudo -n chown 1000:1000 weaviate_data
             echo "[remote] starting weaviate"
             sudo -n docker compose up -d weaviate
             echo "[remote] reset complete"'


### PR DESCRIPTION
**What Changed**

Updated the Cloud Build Weaviate reset step to run Docker commands with non-interactive `sudo`:

```bash
sudo -n docker compose stop weaviate
sudo -n docker compose up -d weaviate
```

Also updated the reset flow to change ownership of the recreated Weaviate data directory before restarting the container:

```bash
sudo -n chown -R 1000:1000 weaviate_data
```

**Why We Needed To Change It**

The test deployment was failing during the `reset-weaviate-data` step because the Cloud Build SSH user on the GCE VM did not have permission to access Docker:

```text
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```

[AS PART OF COPILOT  TICKET] Using `sudo -n docker compose` lets the deployment reset and restart Weaviate without relying on the SSH user being in the Docker group. The `-n` flag makes sudo non-interactive, so the build fails immediately instead of hanging if passwordless sudo is not available.

[AS PART OF GEMINI TICKET] After the reset, `weaviate_data` is recreated by `sudo mkdir`, which makes it owned by `root:root`. Weaviate writes its persistent data inside that mounted directory, so the directory needs to be owned by the Weaviate container user (`1000:1000`) before the container starts.

[AS SUGGESTED BY gpt-5.6-sol-medium] Deployment stops if Weaviate container cannot be stopped.