### PR TITLE
Fix false unhealthy status for Weaviate and Ollama

### DIFF
--- a/gce-startup.test.js
+++ b/gce-startup.test.js
@@ -1,0 +1,14 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+const startupScript = readFileSync(join(process.cwd(), "scripts", "gce-startup.sh"), "utf-8");
+const composeFile = startupScript.match(/cat > docker-compose\.yml << 'EOF'\n([\s\S]*?)\nEOF/)[1];
+
+describe("GCE startup Compose configuration", () => {
+  it("does not configure healthchecks that require curl in the service images", () => {
+    expect(composeFile).toContain("  weaviate:");
+    expect(composeFile).toContain("  ollama:");
+    expect(composeFile).not.toContain("healthcheck:");
+  });
+});

--- a/scripts/gce-startup.sh
+++ b/scripts/gce-startup.sh
@@ -44,11 +44,6 @@ services:
       - ./weaviate_data:/var/lib/weaviate
     depends_on:
       - ollama
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/.well-known/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   ollama:
     image: ollama/ollama:latest
@@ -57,11 +52,6 @@ services:
       - "11434:11434"
     volumes:
       - ./ollama_data:/root/.ollama
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 EOF
 
 # Start services


### PR DESCRIPTION
# Fix false unhealthy status for Weaviate and Ollama

Closes #144.

## What was wrong?

The GCE startup script added Docker healthchecks that ran `curl` inside the Weaviate and Ollama containers. Neither container image includes `curl`, so Docker reported both services as unhealthy even when they were running correctly.

## What changed?

The invalid container-level healthchecks were removed. This only removes the misleading Docker health status; it does not change either service's image, ports, volumes, restart behavior, startup order, or model setup.

### Files changed

- `scripts/gce-startup.sh`
  - Removed the Weaviate healthcheck that tried to run the unavailable `curl` command.
  - Removed the Ollama healthcheck that tried to run the unavailable `curl` command.
  - Why: these checks could never succeed with the current images and produced false `unhealthy` statuses.

- `gce-startup.test.js`
  - Added a regression test for the Docker Compose configuration generated by the startup script.
  - Why: this prevents the broken container healthchecks from being accidentally reintroduced while confirming that both service definitions remain present.

## What should the reviewer check?

1. Confirm that only the two invalid healthcheck blocks were removed from `scripts/gce-startup.sh`.
2. Confirm that the Weaviate and Ollama runtime configuration is otherwise unchanged.
3. Confirm that the regression test clearly protects the behavior described in issue #144.

## Test evidence

- `npx vitest run gce-startup.test.js` — passed: 1 test.
- `bash -n scripts/gce-startup.sh` — passed.
- Generated Compose YAML checked with `docker compose config --quiet` — passed.
- `git diff --check` — passed.
- Full `npm test` run — 124 tests passed and 19 unrelated existing `worker.test.js` tests failed. The failures concern language handling and removed FAQ helpers; this PR does not change those areas.

## TEST-environment verification

No additional local testing is required. After this change is applied to the TEST VM, run:

```bash
docker ps
curl http://localhost:8080/v1/.well-known/ready
curl http://localhost:11434/
```

Expected result:

- Weaviate and Ollama show as `Up` without a false `unhealthy` status.
- Both endpoint checks succeed.

An existing VM may still contain the old generated `/opt/iitm-chatbot/docker-compose.yml`. Merging this PR alone may therefore not update that VM. The startup script must be reapplied through the normal TEST-environment process, or the VM must otherwise receive the updated Compose configuration, before performing this verification.

## Risk and rollback

- Docker will no longer publish a health status for these two containers. Actual service availability remains verifiable through their HTTP endpoints.
- Process failures are still handled by the existing `restart: always` configuration.
- Rollback is limited to reverting this PR, although that would restore the known false-healthcheck problem.

## Reviewer action

- Review the two changed implementation/test files against the checklist above.
- Approve if the focused change and test are clear.
- After delivery to TEST, ensure the three manual verification commands succeed.
