### PR TITLE
Parallelize document and FAQ retrieval

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1042,9 +1042,11 @@ async function answer(request, env) {
         console.log('[DEBUG] Detected language:', detectedLanguage);
         console.log('[DEBUG] Clean query for search:', cleanQuery);
 
-        // Search Weaviate for relevant documents using clean query (without language tag)
-        const documentResult = await searchWeaviate(cleanQuery, numDocs, env);
-        const faqResult = await fetchPgFaqs(cleanQuery, 5, env);
+        // These searches only need the cleaned query, so start them together.
+        const [documentResult, faqResult] = await Promise.all([
+          searchWeaviate(cleanQuery, numDocs, env),
+          fetchPgFaqs(cleanQuery, 5, env),
+        ]);
         const documents = documentResult?.items || [];
         const dbFaqs = faqResult?.items || [];
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -1430,4 +1430,61 @@ describe("POST /answer retrieval control flow", () => {
       error: "pg_faqs_empty",
     });
   });
+
+  it("starts both retrieval calls before either one finishes", async () => {
+    let finishWeaviate;
+    let finishFaqs;
+    const weaviateResponse = new Promise((resolve) => {
+      finishWeaviate = resolve;
+    });
+    const faqResponse = new Promise((resolve) => {
+      finishFaqs = resolve;
+    });
+    const startedUrls = [];
+
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes("/v1/graphql")) {
+        startedUrls.push("weaviate");
+        return weaviateResponse;
+      }
+      if (url.includes("/search")) {
+        startedUrls.push("faqs");
+        return faqResponse;
+      }
+      if (url === routeEnv.CHAT_API_ENDPOINT) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: '{"approved":"YES","incorrect":[]}' } }],
+          }),
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const responsePromise = worker.fetch(answerRequest(), routeEnv);
+
+    await vi.waitFor(() => {
+      expect(startedUrls).toEqual(["weaviate", "faqs"]);
+    });
+
+    finishWeaviate({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          data: { Get: { Document: [] } },
+        }),
+    });
+    finishFaqs({
+      ok: true,
+      json: async () => ({
+        results: [{ id: "faq-1", question: "What are the fees?", answer: "See the fee table." }],
+      }),
+    });
+
+    const response = await responsePromise;
+    await response.text();
+
+    expect(startedUrls).toEqual(["weaviate", "faqs"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Run Weaviate document retrieval and PG FAQ retrieval concurrently.
- Preserve the current retrieval result envelopes and error diagnostics.
- Add a regression test proving both calls start before either finishes.

## Testing
- Focused retrieval-control tests: 3 passed.
- Full suite: 143 passed; 19 unrelated existing failures in worker.test.js.
- git diff --check: passed.

## Review note
This PR intentionally contains only the minimal concurrency change and test. It replaces the conflicted PR #137.